### PR TITLE
feat: OAuth認可画面の日本語化とUI改善

### DIFF
--- a/src/app/oauth/authorize/page.tsx
+++ b/src/app/oauth/authorize/page.tsx
@@ -50,11 +50,10 @@ export default async function AuthorizePage({
     return (
       <main className="flex items-center justify-center h-screen">
         <div className="bg-white p-8 rounded-lg shadow-md max-w-sm w-full text-center">
-          <h1 className="text-2xl font-bold mb-4">Error</h1>
-          <p>Invalid authorization request.</p>
+          <h1 className="text-2xl font-bold mb-4">エラー</h1>
+          <p>不正な認可リクエストです。</p>
           <p className="text-xs text-gray-500 mt-4">
-            Missing client_id, redirect_uri, or response_type is not
-            &apos;code&apos;.
+            client_id、redirect_uri が不足しているか、response_type が &apos;code&apos; ではありません。
           </p>
         </div>
       </main>
@@ -70,8 +69,8 @@ export default async function AuthorizePage({
     return (
       <main className="flex items-center justify-center h-screen">
         <div className="bg-white p-8 rounded-lg shadow-md max-w-sm w-full text-center">
-          <h1 className="text-2xl font-bold mb-4">Error</h1>
-          <p>Invalid client or redirect URI.</p>
+          <h1 className="text-2xl font-bold mb-4">エラー</h1>
+          <p>不正なクライアントまたはリダイレクトURIです。</p>
         </div>
       </main>
     );
@@ -88,10 +87,10 @@ export default async function AuthorizePage({
     return (
       <main className="flex items-center justify-center h-screen">
         <div className="bg-white p-8 rounded-lg shadow-md max-w-sm w-full text-center">
-          <h1 className="text-2xl font-bold mb-4">Error</h1>
-          <p>Workspace not found for the current user.</p>
+          <h1 className="text-2xl font-bold mb-4">エラー</h1>
+          <p>現在のユーザーのワークスペースが見つかりません。</p>
           <p className="text-xs text-gray-500 mt-4">
-            Please connect a workspace before authorizing.
+            認可する前にワークスペースを接続してください。
           </p>
         </div>
       </main>
@@ -143,39 +142,113 @@ export default async function AuthorizePage({
   }
 
   return (
-    <main className="flex items-center justify-center h-screen bg-gray-50">
-      <div className="bg-white p-8 rounded-lg shadow-md max-w-sm w-full">
-        <h1 className="text-xl font-semibold mb-4 text-center">
-          Authorize Application
-        </h1>
-        <div className="text-center">
-          <p className="mb-2">
-            The application{" "}
-            <strong className="font-medium">{client.name}</strong> is requesting
-            access to your account.
-          </p>
-          <p className="text-sm text-gray-600">Do you want to grant access?</p>
+    <main className="flex items-center justify-center min-h-screen bg-gray-50 p-4">
+      <div className="bg-white p-8 rounded-lg shadow-lg max-w-md w-full">
+        <div className="text-center mb-6">
+          <div className="inline-flex items-center justify-center w-16 h-16 bg-blue-100 rounded-full mb-4">
+            <svg
+              className="w-8 h-8 text-blue-600"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
+              />
+            </svg>
+          </div>
+          <h1 className="text-2xl font-bold text-gray-900 mb-2">
+            アプリケーションの認可
+          </h1>
         </div>
-        <form action={handleConsent} className="mt-6">
-          <div className="flex justify-center gap-4">
+
+        <div className="bg-gray-50 p-4 rounded-lg mb-6">
+          <p className="text-sm text-gray-600 mb-2">アプリケーション</p>
+          <p className="text-lg font-semibold text-gray-900">{client.name}</p>
+        </div>
+
+        <div className="mb-6">
+          <p className="text-gray-700 mb-4">
+            このアプリケーションがあなたのアカウントへのアクセスを要求しています。
+          </p>
+          <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
+            <p className="text-sm font-medium text-blue-900 mb-2">
+              許可される操作:
+            </p>
+            <ul className="text-sm text-blue-800 space-y-1">
+              <li className="flex items-start">
+                <svg
+                  className="w-4 h-4 mr-2 mt-0.5 flex-shrink-0"
+                  fill="currentColor"
+                  viewBox="0 0 20 20"
+                >
+                  <path
+                    fillRule="evenodd"
+                    d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+                タスクの作成と更新
+              </li>
+              <li className="flex items-start">
+                <svg
+                  className="w-4 h-4 mr-2 mt-0.5 flex-shrink-0"
+                  fill="currentColor"
+                  viewBox="0 0 20 20"
+                >
+                  <path
+                    fillRule="evenodd"
+                    d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+                進捗状況の報告
+              </li>
+              <li className="flex items-start">
+                <svg
+                  className="w-4 h-4 mr-2 mt-0.5 flex-shrink-0"
+                  fill="currentColor"
+                  viewBox="0 0 20 20"
+                >
+                  <path
+                    fillRule="evenodd"
+                    d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+                ワークスペース情報の読み取り
+              </li>
+            </ul>
+          </div>
+        </div>
+
+        <form action={handleConsent}>
+          <div className="flex flex-col gap-3">
             <button
               type="submit"
               name="consent"
               value="allow"
-              className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-50"
+              className="w-full px-4 py-3 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors"
             >
-              Allow
+              許可する
             </button>
             <button
               type="submit"
               name="consent"
               value="deny"
-              className="px-4 py-2 bg-gray-200 text-gray-800 rounded-md hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-opacity-50"
+              className="w-full px-4 py-3 bg-white text-gray-700 font-medium border border-gray-300 rounded-lg hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2 transition-colors"
             >
-              Deny
+              拒否する
             </button>
           </div>
         </form>
+
+        <p className="text-xs text-gray-500 text-center mt-6">
+          許可することで、このアプリケーションが上記の操作を実行できるようになります。
+        </p>
       </div>
     </main>
   );


### PR DESCRIPTION
## 概要

OAuth認可画面を日本語化し、ユーザーにとってよりわかりやすく使いやすいUIに改善しました。

## 変更内容

### 日本語化
- すべてのテキストを日本語に翻訳
- エラーメッセージも日本語化
- より自然な日本語表現を使用

### UI改善

**ビジュアル要素**
- セキュリティを示す鍵アイコンを追加
- 青い円形背景でアイコンを強調
- アプリケーション名を専用セクションで表示

**権限表示**
- 許可される操作を明確にリスト化
- チェックマークアイコンで視覚的にわかりやすく
- 青い情報ボックスで権限スコープを目立たせ

**レイアウト**
- ボタンを縦並びの全幅表示に変更
- モバイルフレンドリーなレスポンシブデザイン
- より大きく、タップしやすいボタン

**アクセシビリティ**
- カラーコントラストの改善
- フォーカスリングの明確化
- 画面サイズに応じた適切なパディング

### 詳細な権限説明

ユーザーが何を許可するのかを明確に理解できるよう、以下の情報を表示：
- タスクの作成と更新
- 進捗状況の報告
- ワークスペース情報の読み取り

### その他
- 許可の意味を説明する注意書きを追加
- グレー背景カードでコンテンツを整理

## スクリーンショット

改善後のUIは、よりプロフェッショナルで信頼感のあるデザインになりました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)