### PR TITLE
feat: タスク完了時にSlackスレッドのメッセージにリアクションを追加

### DIFF
--- a/src/app/create-app.ts
+++ b/src/app/create-app.ts
@@ -2,14 +2,11 @@ import { Database, db } from "@/clients/drizzle"
 import { createFactory } from "hono/factory"
 import * as schema from "@/db/schema";
 
-type User = typeof schema.users.$inferSelect;
-type Workspace = typeof schema.workspaces.$inferSelect;
-
 export type Env = {
   Variables: {
     db: Database
-    user: User
-    workspace: Workspace
+    user: schema.User
+    workspace: schema.Workspace
   }
 }
 

--- a/src/lib/slackInstall.ts
+++ b/src/lib/slackInstall.ts
@@ -3,7 +3,13 @@ import { absoluteUrl } from "./utils";
 const SLACK_OAUTH_ENDPOINT = "https://slack.com/oauth/v2/authorize";
 const SLACK_TOKEN_ENDPOINT = "https://slack.com/api/oauth.v2.access";
 
-const DEFAULT_SCOPES = ["chat:write", "chat:write.public", "channels:read", "groups:read"];
+const DEFAULT_SCOPES = [
+    "chat:write",
+    "chat:write.public",
+    "channels:read",
+    "groups:read",
+    "reactions:write",
+];
 
 type SlackInstallConfig = {
     clientId: string;

--- a/src/lib/taskNotifications.ts
+++ b/src/lib/taskNotifications.ts
@@ -1,4 +1,4 @@
-import { postMessage } from "../clients/slack";
+import { postMessage, addReaction } from "../clients/slack";
 import { db } from "../clients/drizzle";
 import * as schema from "../db/schema";
 import { createWorkspaceRepository, createTaskRepository } from "../repos";
@@ -375,6 +375,19 @@ export const notifyTaskCompleted = async (
             text,
             threadTs: session.slackThreadTs,
         });
+
+        // Add completion reaction to the thread's first message
+        try {
+            await addReaction({
+                token: config.token,
+                channel: session.slackChannel,
+                timestamp: session.slackThreadTs,
+                name: "white_check_mark",
+            });
+        } catch (reactionError) {
+            // Log error but don't fail the entire operation
+            console.error("Failed to add reaction to completed task", reactionError);
+        }
 
         return {
             delivered: true,


### PR DESCRIPTION
## 概要

タスク完了時に、Slackスレッドの最初のメッセージに完了を示すリアクション（✅）を自動的に追加する機能を実装しました。

## 変更内容

### 1. Slack APIクライアントの拡張 (`src/clients/slack.ts`)
- `addReaction` 関数を追加
- `reactions.add` APIエンドポイントを使用
- `already_reacted` エラーを適切にハンドリング

### 2. Slackインストールスコープの追加 (`src/lib/slackInstall.ts`)
- `reactions:write` スコープを `DEFAULT_SCOPES` に追加

### 3. タスク完了通知の強化 (`src/lib/taskNotifications.ts`)
- `notifyTaskCompleted` 関数内でリアクション追加処理を呼び出し
- エラーが発生してもタスク完了処理は継続するように実装

### 4. 型定義の改善 (`src/app/create-app.ts`)
- スキーマからの型推論を統一

## 動作

1. `complete_task` MCPツールが呼ばれると、Slackスレッドに完了メッセージを投稿
2. その後、スレッドの最初のメッセージ（`thread_ts`）に `:white_check_mark:` (✅) リアクションを追加
3. リアクション追加が失敗してもタスク完了処理は継続

## テスト

- ✅ 型チェック通過
- ✅ ビルド成功

## 注意事項

既存のSlackワークスペースでは、ボットの再インストールが必要です（`reactions:write` スコープを追加するため）。

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)