### PR TITLE
refactor: migrate daily summary API to Hono

### DIFF
--- a/src/app/[...route]/route.ts
+++ b/src/app/[...route]/route.ts
@@ -6,6 +6,7 @@ import { createMcpServer } from "../mcp";
 import oauthRoutes from "../../routes/oauth"
 import authRoutes from "../../routes/auth"
 import slackRoutes from "../../routes/slack"
+import dailySummaryRoutes from "../../routes/daily-summary"
 import { oauthMiddleware } from '@/middleware/oauth';
 import { createHonoApp } from '../create-app';
 
@@ -14,6 +15,7 @@ const app = createHonoApp()
 app.route("/", oauthRoutes)
 app.route("/login", authRoutes)
 app.route("/slack", slackRoutes)
+app.route("/api/daily-summary", dailySummaryRoutes)
 
 app.all(
   "/mcp",


### PR DESCRIPTION
## 対応するIssue

close N/A

## やること

- [x] daily-summary APIをHonoに移行
  - [x] Next.js route handler (src/app/api/daily-summary/route.ts) を Hono route (src/routes/daily-summary.ts) に移動
  - [x] 認証方式を getCurrentSession() から oauthMiddleware に変更
  - [x] メインアプリに /api/daily-summary ルートを登録
  - [x] 未使用のimport (workspaceRepository) を削除
  - [x] 既存機能（タスク取得、LLM要約、Slack投稿）を維持

## やらないこと

特になし

## 動作確認方法

1. OAuth認証済みのアクセストークンを取得
2. `POST /api/daily-summary` にアクセストークンを付けてリクエスト
3. 本日のタスク活動が要約され、Slackに投稿されることを確認

## その他補足

- Next.jsのルートハンドラーからHonoへの移行により、認証とルーティングが統一されました
- エンドポイントのパスは変更なし（`POST /api/daily-summary`）
- レスポンス形式も既存と同じ
