### PR TITLE
feat: add OAuth authorization validation and comprehensive tests

### DIFF
--- a/docs/schema-testing-guidelines.md
+++ b/docs/schema-testing-guidelines.md
@@ -1,0 +1,255 @@
+# スキーマテストガイドライン
+
+このドキュメントは、コードベース内のZodスキーマのテストを書く際のベストプラクティスとガイドラインをまとめたものです。
+
+## 概要
+
+スキーマテストは、Zodスキーマが入力データを正しく検証することを保証します。このガイドでは、保守性が高く型安全なスキーマテストを書くためのパターンを説明します。
+
+## 型安全なテストフィクスチャ
+
+### 型推論には `z.input` を使用する
+
+テストフィクスチャを定義する際は、`z.input<typeof Schema>` を使用してスキーマから入力型を推論します。これにより型安全性が確保され、スキーマ定義とテストデータの乖離を防げます。
+
+`z.input` を使う理由は、スキーマが唯一の型定義となり、別途型をエクスポートする必要がなくなるためです。また、`z.infer` は変換（transform）が適用された後の型を提供するのに対し、`z.input` は変換前の入力型を提供するため、テストデータの定義により適しています。
+
+```typescript
+import type { z } from "zod";
+import { UserSchema } from "./user.schema";
+
+// ✅ 良い例: z.inputを使用した型安全なフィクスチャ
+const fixtures: z.input<typeof UserSchema>[] = [
+  {
+    name: "山田太郎",
+    email: "yamada@example.com",
+    age: 30,
+  },
+];
+
+// ❌ 悪い例: 別途型をインポートする
+import { type User } from "./user.schema";
+const fixtures: User[] = [...];
+```
+
+### インポート順序
+
+APIスキーマを扱う際は、常に `zod` から `z` 型をインポートします：
+
+```typescript
+import type { z } from "zod";
+import { assert, describe, expect, it } from "vitest";
+import { YourSchema } from "./your.schema";
+```
+
+## テストパターン
+
+### 正常系テストケース
+
+スキーマ検証を通過すべき有効な入力をテストします：
+
+```typescript
+describe("CreateUserSchema", () => {
+  it("正常なデータの場合は成功する", () => {
+    const fixtures: z.input<typeof CreateUserSchema>[] = [
+      {
+        name: "テストユーザー",
+        email: "test@example.com",
+      },
+      // 他の有効なテストケースを追加
+    ];
+
+    for (const fixture of fixtures) {
+      expect(fixture).toEqual(expect.schemaMatching(CreateUserSchema));
+    }
+  });
+});
+```
+
+### 型制約を考慮した異常系テストケース
+
+無効な入力をテストする場合、以下の2つの選択肢があります：
+
+#### 選択肢1: 型として有効なエラーケースのみをテスト
+
+型としては有効だが、検証で失敗すべきエッジケースに焦点を当てます：
+
+```typescript
+it("不正なデータの場合は失敗する", () => {
+  const fixtures: [z.input<typeof CreateUserSchema>, string[]][] = [
+    // 境界条件のテスト
+    [
+      {
+        name: "", // 空文字列 - 型は有効だが最小長で失敗すべき
+        email: "test@example.com",
+      },
+      ["String must contain at least 1 character(s)"],
+    ],
+    // フォーマット検証のテスト
+    [
+      {
+        name: "テストユーザー",
+        email: "invalid-email", // 無効なメールフォーマット
+      },
+      ["Invalid email"],
+    ],
+  ];
+
+  for (const [fixture, errors] of fixtures) {
+    const res = CreateUserSchema.safeParse(fixture);
+    expect.assert(!res.success);
+    expect(errors).toEqual(res.error.issues.map((e) => e.message));
+  }
+});
+```
+
+#### 選択肢2: 型として無効なテストケースを削除
+
+厳密な型（enumなど）を持つスキーマでは、型として無効な入力のテストを避けます：
+
+```typescript
+// enum型の例: z.enum(["asc", "desc"])
+describe("sortOrder", () => {
+  it("正常なデータの場合は成功する", () => {
+    const fixtures = ["asc", "desc"];
+
+    for (const fixture of fixtures) {
+      expect(sortOrder.safeParse(fixture).success).toBeTruthy();
+    }
+  });
+
+  // ❌ "invalid"、123、nullなど型として無効な値はテストしない
+  // TypeScriptコンパイラが既に型安全性を保証している
+});
+```
+
+## ベストプラクティス
+
+### 1. ビジネスロジックの検証に焦点を当てる
+
+型システムの保証よりも、ビジネスルールと検証ロジックのテストを優先します：
+
+- ✅ テストすべき: 最小/最大長、正規表現パターン、カスタムリファインメント
+- ❌ スキップすべき: 誤った型（文字列 vs 数値）、null vs オブジェクト
+
+### 2. 説明的なテスト名を使用する
+
+テストが何を検証しているかを日本語または英語で一貫して記述します：
+
+```typescript
+it("メールアドレスの形式が不正な場合は失敗する", () => {
+  // 無効なメールフォーマットをテスト
+});
+
+it("名前が80文字を超える場合は失敗する", () => {
+  // 最大長の検証をテスト
+});
+```
+
+### 3. 関連するテストをグループ化する
+
+スキーマと検証の観点でテストを整理します：
+
+```typescript
+describe("UserSchema", () => {
+  describe("nameフィールド", () => {
+    it("有効な名前を受け入れる", () => {
+      /* ... */
+    });
+    it("空の名前を拒否する", () => {
+      /* ... */
+    });
+    it("100文字を超える名前を拒否する", () => {
+      /* ... */
+    });
+  });
+
+  describe("emailフィールド", () => {
+    it("有効なメールフォーマットを受け入れる", () => {
+      /* ... */
+    });
+    it("無効なメールフォーマットを拒否する", () => {
+      /* ... */
+    });
+  });
+});
+```
+
+### 4. 型システムの過剰なテストを避ける
+
+TypeScriptとZodの型システムは既にコンパイル時の保証を提供しています。以下に焦点を当ててテストします：
+
+- ランタイム検証ロジック
+- ビジネスルール
+- 型制約内のエッジケース
+- カスタムリファインメントと変換
+
+### 5. 一貫性を保つ
+
+- すべてのスキーマテストで同じパターンを使用する
+- 確立されたフィクスチャ構造に従う
+- テストデータを現実的で意味のあるものに保つ
+
+## 例
+
+### 完全なテストファイルの例
+
+```typescript
+import type { z } from "zod";
+import { assert, describe, expect, it } from "vitest";
+import { CreateProductSchema, UpdateProductSchema } from "./product.schema";
+
+describe("product.schema", () => {
+  describe("CreateProductSchema", () => {
+    it("正常なデータの場合は成功する", () => {
+      const fixtures: z.input<typeof CreateProductSchema>[] = [
+        {
+          name: "テスト商品",
+          price: 1000,
+          description: "テスト用の商品",
+          categoryId: "123e4567-e89b-12d3-a456-426614174000",
+        },
+        {
+          name: "別の商品",
+          price: 0, // エッジケースのテスト: 無料商品
+          description: "無料商品",
+          categoryId: "123e4567-e89b-12d3-a456-426614174000",
+        },
+      ];
+
+      for (const fixture of fixtures) {
+        expect(CreateProductSchema.safeParse(fixture).success).toBeTruthy();
+      }
+    });
+
+    it("不正なデータの場合は失敗する", () => {
+      const fixtures: [z.input<typeof CreateProductSchema>, string[]][] = [
+        [
+          {
+            name: "", // 空の名前
+            price: 1000,
+            description: "テスト",
+            categoryId: "123e4567-e89b-12d3-a456-426614174000",
+          },
+          ["String must contain at least 1 character(s)"],
+        ],
+        [
+          {
+            name: "テスト商品",
+            price: -100, // 負の価格
+            description: "テスト",
+            categoryId: "123e4567-e89b-12d3-a456-426614174000",
+          },
+          ["Number must be greater than or equal to 0"],
+        ],
+      ];
+
+      for (const [fixture, errors] of fixtures) {
+        const res = CreateProductSchema.safeParse(fixture);
+        expect.assert(!res.success);
+        expect(errors).toEqual(res.error.issues.map((e) => e.message));
+      }
+    });
+  });
+});
+```

--- a/src/app/create-app.ts
+++ b/src/app/create-app.ts
@@ -5,6 +5,8 @@ import * as schema from "@/db/schema";
 import { Schema } from "../../env";
 import { AiSdkModels, createAiSdkModels } from "@/lib/ai";
 import { env } from "hono/adapter";
+import { secureHeaders } from "hono/secure-headers";
+import { logger } from "hono/logger";
 
 export type Env = {
   Bindings: Schema;
@@ -54,4 +56,6 @@ export const createHonoApp = () =>
         await next();
       });
     },
-  }).createApp();
+  })
+    .createApp()
+    .use("*", secureHeaders(), logger());

--- a/src/lib/server/oauth.test.ts
+++ b/src/lib/server/oauth.test.ts
@@ -1,0 +1,295 @@
+import type { z } from "zod";
+import { describe, it, expect, beforeEach } from "vitest";
+import { setup } from "../../../tests/vitest.helper";
+
+// vitest.helperの後にインポートする
+import {
+  validateAuthorizeRequest,
+  createLoginRedirectUrl,
+  authorizeRequestSchema,
+} from "./oauth";
+import * as schema from "@/db/schema";
+import { uuidv7 } from "uuidv7";
+
+const { db } = await setup();
+
+describe("lib/server/oauth", () => {
+  describe("authorizeRequestSchema", () => {
+    it("正常なデータの場合は成功する", () => {
+      const fixtures: z.input<typeof authorizeRequestSchema>[] = [
+        // 最小限の必須パラメータ
+        {
+          client_id: "test-client-id",
+          redirect_uri: "https://example.com/callback",
+          response_type: "code",
+        },
+        // すべてのオプショナルパラメータを含む
+        {
+          client_id: "test-client-id",
+          redirect_uri: "https://example.com/callback",
+          response_type: "code",
+          state: "random-state-value",
+          code_challenge: "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+          code_challenge_method: "S256",
+        },
+        // stateパラメータのみを含む
+        {
+          client_id: "another-client",
+          redirect_uri: "https://app.example.com/oauth/callback",
+          response_type: "code",
+          state: "csrf-token-12345",
+        },
+      ];
+
+      for (const fixture of fixtures) {
+        expect(authorizeRequestSchema.safeParse(fixture).success).toBeTruthy();
+      }
+    });
+
+    it("不正なデータの場合は失敗する", () => {
+      const fixtures: [z.input<typeof authorizeRequestSchema>, string[]][] = [
+        // client_idが空文字列
+        [
+          {
+            client_id: "",
+            redirect_uri: "https://example.com/callback",
+            response_type: "code",
+          },
+          ["Missing client_id"],
+        ],
+        // redirect_uriが不正なURL形式
+        [
+          {
+            client_id: "test-client-id",
+            redirect_uri: "not-a-valid-url",
+            response_type: "code",
+          },
+          ["redirect_uri must be a valid URL"],
+        ],
+        // response_typeが'code'以外
+        [
+          {
+            client_id: "test-client-id",
+            redirect_uri: "https://example.com/callback",
+            response_type: "token",
+          },
+          ["response_type must be 'code'"],
+        ],
+        // code_challenge_methodが'S256'以外
+        [
+          {
+            client_id: "test-client-id",
+            redirect_uri: "https://example.com/callback",
+            response_type: "code",
+            code_challenge: "challenge",
+            code_challenge_method: "plain",
+          },
+          ["code_challenge_method must be 'S256'"],
+        ],
+        // code_challenge_methodのみ提供（code_challengeなし）
+        [
+          {
+            client_id: "test-client-id",
+            redirect_uri: "https://example.com/callback",
+            response_type: "code",
+            code_challenge_method: "S256",
+          },
+          ["code_challengeとcode_challenge_methodは両方提供する必要があります"],
+        ],
+        // code_challengeのみ提供（code_challenge_methodなし）
+        [
+          {
+            client_id: "test-client-id",
+            redirect_uri: "https://example.com/callback",
+            response_type: "code",
+            code_challenge: "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+          },
+          ["code_challengeとcode_challenge_methodは両方提供する必要があります"],
+        ],
+      ];
+
+      for (const [fixture, expectedErrors] of fixtures) {
+        const res = authorizeRequestSchema.safeParse(fixture);
+        expect.assert(!res.success);
+        expect(expectedErrors).toEqual(res.error.issues.map((e) => e.message));
+      }
+    });
+  });
+
+  describe("validateAuthorizeRequest", () => {
+    let testClient: typeof schema.clients.$inferSelect;
+
+    beforeEach(async () => {
+      // テスト用のクライアントを作成
+      const [client] = await db
+        .insert(schema.clients)
+        .values({
+          id: uuidv7(),
+          clientId: "test-client-id",
+          name: "Test Client",
+          redirectUris: ["https://example.com/callback"],
+        })
+        .returning();
+
+      testClient = client;
+    });
+
+    it("有効なリクエストとクライアントで成功を返す", async () => {
+      const params = {
+        client_id: "test-client-id",
+        redirect_uri: "https://example.com/callback",
+        response_type: "code",
+      };
+
+      const result = await validateAuthorizeRequest(params);
+
+      expect(result.success).toBe(true);
+      expect(result).toHaveProperty("client");
+      expect(result).toHaveProperty("requestParams");
+      expect(
+        (result as { success: true; client: typeof testClient }).client.id,
+      ).toBe(testClient.id);
+      expect(
+        (
+          result as {
+            success: true;
+            requestParams: { client_id: string };
+          }
+        ).requestParams.client_id,
+      ).toBe("test-client-id");
+    });
+
+    it("不正なパラメータでエラーを返す", async () => {
+      const params = {
+        client_id: "",
+        redirect_uri: "not-a-url",
+        response_type: "code",
+      };
+
+      const result = await validateAuthorizeRequest(params);
+
+      expect.assert(!result.success);
+      expect((result as { success: false; error: string }).error).toBe(
+        "invalid_request",
+      );
+      expect(
+        (result as { success: false; errorDescription?: string })
+          .errorDescription,
+      ).toContain("client_id");
+    });
+
+    it("存在しないクライアントでエラーを返す", async () => {
+      const params = {
+        client_id: "non-existent-client",
+        redirect_uri: "https://example.com/callback",
+        response_type: "code",
+      };
+
+      const result = await validateAuthorizeRequest(params);
+
+      expect.assert(!result.success);
+      expect((result as { success: false; error: string }).error).toBe(
+        "invalid_client",
+      );
+      expect(
+        (result as { success: false; errorDescription?: string })
+          .errorDescription,
+      ).toContain("不正なクライアント");
+    });
+
+    it("登録されていないリダイレクトURIでエラーを返す", async () => {
+      const params = {
+        client_id: "test-client-id",
+        redirect_uri: "https://malicious.com/callback",
+        response_type: "code",
+      };
+
+      const result = await validateAuthorizeRequest(params);
+
+      expect.assert(!result.success);
+      expect((result as { success: false; error: string }).error).toBe(
+        "invalid_request",
+      );
+      expect(
+        (result as { success: false; errorDescription?: string })
+          .errorDescription,
+      ).toContain("リダイレクトURI");
+    });
+  });
+
+  describe("createLoginRedirectUrl", () => {
+    it("パラメータを保持したログインURLを生成する", () => {
+      const params = {
+        client_id: "test-client-id",
+        redirect_uri: "https://example.com/callback",
+        response_type: "code",
+        state: "random-state",
+      };
+
+      const url = createLoginRedirectUrl(params);
+
+      expect(url).toContain("/login");
+      expect(url).toContain("callbackUrl=");
+
+      // URLをパースして検証
+      const parsedUrl = new URL(url);
+      const callbackUrl = parsedUrl.searchParams.get("callbackUrl");
+      expect(callbackUrl).toBeTruthy();
+
+      const parsedCallback = new URL(callbackUrl!);
+      expect(parsedCallback.pathname).toBe("/oauth/authorize");
+      expect(parsedCallback.searchParams.get("client_id")).toBe(
+        "test-client-id",
+      );
+      expect(parsedCallback.searchParams.get("redirect_uri")).toBe(
+        "https://example.com/callback",
+      );
+      expect(parsedCallback.searchParams.get("response_type")).toBe("code");
+      expect(parsedCallback.searchParams.get("state")).toBe("random-state");
+    });
+
+    it("文字列以外のパラメータは無視される", () => {
+      const params = {
+        client_id: "test-client-id",
+        redirect_uri: "https://example.com/callback",
+        response_type: "code",
+        numeric_param: 123,
+        array_param: ["a", "b"],
+        object_param: { key: "value" },
+      };
+
+      const url = createLoginRedirectUrl(params);
+      const parsedUrl = new URL(url);
+      const callbackUrl = parsedUrl.searchParams.get("callbackUrl");
+
+      const parsedCallback = new URL(callbackUrl!);
+      // 文字列パラメータのみ含まれる
+      expect(parsedCallback.searchParams.get("client_id")).toBe(
+        "test-client-id",
+      );
+      expect(parsedCallback.searchParams.get("redirect_uri")).toBe(
+        "https://example.com/callback",
+      );
+      expect(parsedCallback.searchParams.get("response_type")).toBe("code");
+      // 文字列以外は含まれない
+      expect(parsedCallback.searchParams.has("numeric_param")).toBe(false);
+      expect(parsedCallback.searchParams.has("array_param")).toBe(false);
+      expect(parsedCallback.searchParams.has("object_param")).toBe(false);
+    });
+
+    it("空のパラメータでもURLを生成できる", () => {
+      const params = {};
+      const url = createLoginRedirectUrl(params);
+
+      expect(url).toContain("/login");
+      expect(url).toContain("callbackUrl=");
+
+      const parsedUrl = new URL(url);
+      const callbackUrl = parsedUrl.searchParams.get("callbackUrl");
+      expect(callbackUrl).toBeTruthy();
+
+      const parsedCallback = new URL(callbackUrl!);
+      expect(parsedCallback.pathname).toBe("/oauth/authorize");
+    });
+  });
+});

--- a/src/lib/server/oauth.ts
+++ b/src/lib/server/oauth.ts
@@ -1,0 +1,118 @@
+import { z } from "zod";
+import * as schema from "@/db/schema";
+import { eq } from "drizzle-orm";
+import { db } from "@/clients/drizzle";
+import { absoluteUrl } from "@/lib/utils";
+
+export const authorizeRequestSchema = z
+  .object({
+    client_id: z.string().min(1, "Missing client_id"),
+    redirect_uri: z.url({ message: "redirect_uri must be a valid URL" }),
+    response_type: z
+      .string()
+      .refine((responseType) => responseType === "code", {
+        message: "response_type must be 'code'",
+      }),
+    state: z.string().max(1024).optional(),
+    code_challenge: z.string().max(190).optional(),
+    code_challenge_method: z
+      .string()
+      .refine((method) => method === "S256", {
+        message: "code_challenge_method must be 'S256'",
+      })
+      .optional(),
+  })
+  .refine(
+    (data) => {
+      // code_challenge_methodが提供された場合、code_challengeも必須
+      if (data.code_challenge_method && !data.code_challenge) {
+        return false;
+      }
+      // code_challengeが提供された場合、code_challenge_methodも必須
+      if (data.code_challenge && !data.code_challenge_method) {
+        return false;
+      }
+      return true;
+    },
+    {
+      message:
+        "code_challengeとcode_challenge_methodは両方提供する必要があります",
+    },
+  );
+
+export type ValidateAuthorizeRequestResult =
+  | {
+      success: true;
+      requestParams: z.infer<typeof authorizeRequestSchema>;
+      client: typeof schema.clients.$inferSelect;
+    }
+  | {
+      success: false;
+      error: string;
+      errorDescription?: string;
+    };
+
+export const validateAuthorizeRequest = async (
+  params: Record<string, unknown>,
+): Promise<ValidateAuthorizeRequestResult> => {
+  const request = authorizeRequestSchema.safeParse(params);
+
+  if (!request.success) {
+    return {
+      success: false,
+      error: "invalid_request",
+      errorDescription:
+        "client_id、redirect_uri が不足しているか、response_typeがcodeではありません。",
+    };
+  }
+
+  const { client_id: clientId, redirect_uri: redirectUri } = request.data;
+
+  const [client] = await db
+    .select()
+    .from(schema.clients)
+    .where(eq(schema.clients.clientId, clientId));
+
+  if (!client) {
+    return {
+      success: false,
+      error: "invalid_client",
+      errorDescription: "不正なクライアントです。",
+    };
+  }
+
+  if (!client.redirectUris.includes(redirectUri)) {
+    return {
+      success: false,
+      error: "invalid_request",
+      errorDescription: "リダイレクトURIが登録されていません。",
+    };
+  }
+
+  return {
+    success: true,
+    requestParams: request.data,
+    client,
+  };
+};
+
+/**
+ * ログインページへリダイレクトするためのURLを作成する
+ * OAuth認可リクエストのパラメータを保持したコールバックURLを含む
+ */
+export const createLoginRedirectUrl = (
+  params: Record<string, unknown>,
+): string => {
+  const loginUrl = new URL(absoluteUrl("/login"));
+  const callbackUrl = new URL(absoluteUrl("/oauth/authorize"));
+
+  // 現在のすべてのクエリパラメータをコールバックURLに追加する
+  Object.entries(params).forEach(([key, value]) => {
+    if (typeof value === "string") {
+      callbackUrl.searchParams.set(key, value);
+    }
+  });
+
+  loginUrl.searchParams.set("callbackUrl", callbackUrl.toString());
+  return loginUrl.toString();
+};


### PR DESCRIPTION
## 対応するIssue

close N/A

## やること

- [x] OAuth認可バリデーション機能の実装
  - [e385ad4](https://github.com/yutakobayashidev/ai-task/commit/e385ad4) Zodスキーマによるリクエストパラメータ検証
  - [e385ad4](https://github.com/yutakobayashidev/ai-task/commit/e385ad4) PKCE (RFC 7636)の整合性チェック
  - [e385ad4](https://github.com/yutakobayashidev/ai-task/commit/e385ad4) OAuth 2.0標準エラーコード対応
- [x] AuthorizePageのリファクタリング
  - [e385ad4](https://github.com/yutakobayashidev/ai-task/commit/e385ad4) 重複検証ロジックの削除
  - [e385ad4](https://github.com/yutakobayashidev/ai-task/commit/e385ad4) ログインリダイレクト処理の共通化
- [x] 包括的なテストスイートの追加
  - [e385ad4](https://github.com/yutakobayashidev/ai-task/commit/e385ad4) 実PostgreSQLを使った統合テスト (9 tests)
  - [e385ad4](https://github.com/yutakobayashidev/ai-task/commit/e385ad4) スキーマテストガイドラインに準拠
- [x] ドキュメント整備
  - [e385ad4](https://github.com/yutakobayashidev/ai-task/commit/e385ad4) スキーマテストガイドライン作成

## やらないこと

- トークンエンドポイントの実装（別PRで対応予定）
- scope パラメータのサポート（将来的に必要になったら対応）

## 主な変更内容

### セキュリティ向上

- **PKCE検証強化**: `code_challenge`と`code_challenge_method`の両方が提供されることを強制
- **リダイレクトURI検証**: 登録済みURIとの完全一致チェック
- **OAuth 2.0準拠**: 標準エラーコード(`invalid_request`, `invalid_client`)を返却
- **型安全性**: discriminated unionによる戻り値の型安全性確保

### コード品質

- **DRY原則**: 重複していた検証ロジックを`src/lib/server/oauth.ts`に集約
- **テストカバレッジ**: 9個のテストケースで主要機能とエッジケースをカバー
- **実DB統合テスト**: `tests/vitest.helper.ts`を使用した本番環境に近いテスト
- **スキーマテストガイドライン**: `z.input`を使った型安全なテストパターンを確立

## テスト結果



## その他補足

### レビューポイント

1. **PKCEバリデーション**: `.refine()`を使った相互依存チェックの実装が適切か
2. **エラーメッセージ**: 日本語メッセージとOAuth標準エラーコードの組み合わせ
3. **テストパターン**: スキーマテストガイドラインに準拠しているか

### 今後の課題

- `state`パラメータを推奨からrequiredにするか検討（CSRFトークンとして重要）
- `scope`パラメータのサポート（権限管理が必要になった際）
