### PR TITLE
feat: add header with user menu and logout functionality

### DIFF
--- a/src/app/(private)/dashboard/page.tsx
+++ b/src/app/(private)/dashboard/page.tsx
@@ -11,6 +11,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
+import { Header } from "@/components/header";
 
 function formatDuration(ms: number): string {
   const seconds = Math.floor(ms / 1000);
@@ -95,6 +96,7 @@ export default async function DashboardPage() {
 
   return (
     <div className="min-h-screen bg-slate-50">
+      <Header user={user} className="bg-slate-50" />
       <div className="container mx-auto px-4 py-8">
         <div className="mb-8">
           <h1 className="text-4xl font-bold text-slate-900 mb-2">Dashboard</h1>

--- a/src/app/(public)/login/page.tsx
+++ b/src/app/(public)/login/page.tsx
@@ -26,7 +26,7 @@ export default async function Page() {
 
         <Button asChild size="lg" className="h-11 w-full">
           <Link
-            href="/api/login/slack"
+            href="/api/auth/slack"
             className="flex items-center justify-center gap-2"
           >
             <Slack className="h-4 w-4" />

--- a/src/app/api/[...route]/route.ts
+++ b/src/app/api/[...route]/route.ts
@@ -8,7 +8,7 @@ import { createHonoApp } from "../../create-app";
 const app = createHonoApp().basePath("/api");
 
 app.route("/oauth", oauthRoutes);
-app.route("/login", authRoutes);
+app.route("/auth", authRoutes);
 app.route("/slack", slackRoutes);
 app.route("/health", healthRoutes);
 

--- a/src/app/create-app.ts
+++ b/src/app/create-app.ts
@@ -57,4 +57,4 @@ export const createHonoApp = () =>
     },
   })
     .createApp()
-    .use("*", secureHeaders(), logger());
+    .use(secureHeaders(), logger());

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,6 +13,7 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
 import { siteConfig } from "@/config/site";
+import { Header } from "@/components/header";
 
 export default async function LandingPage() {
   const { user } = await getCurrentSession();
@@ -24,6 +25,7 @@ export default async function LandingPage() {
 
   return (
     <div className="min-h-screen bg-white">
+      <Header user={user} />
       {/* Hero Section */}
       <section className="container mx-auto px-4 py-24 md:py-32">
         <div className="max-w-5xl mx-auto text-center">

--- a/src/clients/authClient.ts
+++ b/src/clients/authClient.ts
@@ -1,0 +1,6 @@
+import { AuthRoute } from "@/handlers/api/auth";
+import { hc } from "hono/client";
+
+export const authClient = hc<AuthRoute>(
+  `${process.env.NEXT_PUBLIC_BASE_URL}/api/auth`,
+);

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { siteConfig } from "@/config/site";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { authClient } from "@/clients/authClient";
+
+type User = {
+  name?: string | null;
+  email?: string | null;
+  imageUrl?: string | null;
+};
+
+type HeaderProps = {
+  user?: User | null;
+  className?: string;
+};
+
+export function Header({ user, className = "bg-white" }: HeaderProps) {
+  const router = useRouter();
+
+  // ユーザーの頭文字を取得
+  const getInitials = (name?: string | null, email?: string | null) => {
+    if (name) {
+      return name
+        .split(" ")
+        .map((n) => n[0])
+        .join("")
+        .toUpperCase()
+        .slice(0, 2);
+    }
+    if (email) {
+      return email[0].toUpperCase();
+    }
+    return "U";
+  };
+
+  const handleLogout = async () => {
+    try {
+      await authClient.logout.$post();
+      router.push("/");
+      router.refresh();
+    } catch (error) {
+      console.error("Logout failed:", error);
+    }
+  };
+
+  return (
+    <header className={className}>
+      <div className="container mx-auto px-4">
+        <div className="flex h-16 items-center justify-between">
+          <Link href="/" className="text-xl font-bold text-slate-900">
+            {siteConfig.name}
+          </Link>
+          {user ? (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  className="relative h-10 w-10 rounded-full"
+                >
+                  <Avatar className="h-10 w-10">
+                    <AvatarImage
+                      src={user.imageUrl ?? undefined}
+                      alt={user.name ?? ""}
+                    />
+                    <AvatarFallback>
+                      {getInitials(user.name, user.email)}
+                    </AvatarFallback>
+                  </Avatar>
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-56">
+                <DropdownMenuLabel>
+                  <div className="flex flex-col space-y-1">
+                    {user.name && (
+                      <p className="text-sm font-medium">{user.name}</p>
+                    )}
+                    {user.email && (
+                      <p className="text-xs text-muted-foreground">
+                        {user.email}
+                      </p>
+                    )}
+                  </div>
+                </DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem asChild>
+                  <Link href="/dashboard">ダッシュボード</Link>
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={handleLogout}>
+                  ログアウト
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          ) : (
+            <Button asChild variant="default">
+              <Link href="/login">ログイン</Link>
+            </Button>
+          )}
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/handlers/api/auth.ts
+++ b/src/handlers/api/auth.ts
@@ -1,79 +1,97 @@
 import { generateState } from "arctic";
-import { getCookie, setCookie } from "hono/cookie";
+import { getCookie, setCookie, deleteCookie } from "hono/cookie";
 import { createHonoApp, getUsecaseContext } from "@/app/create-app";
 import { cors } from "hono/cors";
 import { env } from "hono/adapter";
 import { slack } from "@/lib/oauth";
 import { loginWithSlack } from "@/usecases/auth/loginWithSlack";
+import { invalidateSession, validateSessionToken } from "@/lib/session";
 
-const app = createHonoApp().use(
-  cors({
-    origin: (origin) => origin,
-    credentials: true,
-  }),
-);
+const app = createHonoApp()
+  .use(
+    cors({
+      origin: (origin) => origin,
+      credentials: true,
+    }),
+  )
+  .get("/slack", async (c) => {
+    const { NODE_ENV } = env(c);
+    const state = generateState();
+    const url = slack.createAuthorizationURL(state, [
+      "openid",
+      "profile",
+      "email",
+    ]);
 
-app.get("/slack", async (c) => {
-  const { NODE_ENV } = env(c);
-  const state = generateState();
-  const url = slack.createAuthorizationURL(state, [
-    "openid",
-    "profile",
-    "email",
-  ]);
-
-  setCookie(c, "slack_oauth_state", state, {
-    path: "/",
-    secure: NODE_ENV === "production",
-    httpOnly: true,
-    maxAge: 60 * 10,
-    sameSite: "lax",
-  });
-
-  return new Response(null, {
-    status: 302,
-    headers: {
-      Location: url.toString(),
-    },
-  });
-});
-
-app.get("/slack/callback", async (c) => {
-  const { code, state } = c.req.query();
-  const storedState = getCookie(c, "slack_oauth_state");
-  const { NODE_ENV } = env(c);
-
-  if (
-    !storedState ||
-    !state ||
-    storedState !== state ||
-    typeof code !== "string"
-  ) {
-    return c.text("Bad request", 400);
-  }
-
-  const result = await loginWithSlack({ code }, getUsecaseContext(c));
-
-  if (!result.success) {
-    return new Response("Please restart the process.", {
-      status: 400,
+    setCookie(c, "slack_oauth_state", state, {
+      path: "/",
+      secure: NODE_ENV === "production",
+      httpOnly: true,
+      maxAge: 60 * 10,
+      sameSite: "lax",
     });
-  }
 
-  setCookie(c, "session", result.sessionToken, {
-    httpOnly: true,
-    path: "/",
-    secure: NODE_ENV === "production",
-    sameSite: "lax",
-    expires: result.session.expiresAt,
+    return new Response(null, {
+      status: 302,
+      headers: {
+        Location: url.toString(),
+      },
+    });
+  })
+  .get("/slack/callback", async (c) => {
+    const { code, state } = c.req.query();
+    const storedState = getCookie(c, "slack_oauth_state");
+    const { NODE_ENV } = env(c);
+
+    if (
+      !storedState ||
+      !state ||
+      storedState !== state ||
+      typeof code !== "string"
+    ) {
+      return c.text("Bad request", 400);
+    }
+
+    const result = await loginWithSlack({ code }, getUsecaseContext(c));
+
+    if (!result.success) {
+      return new Response("Please restart the process.", {
+        status: 400,
+      });
+    }
+
+    setCookie(c, "session", result.sessionToken, {
+      httpOnly: true,
+      path: "/",
+      secure: NODE_ENV === "production",
+      sameSite: "lax",
+      expires: result.session.expiresAt,
+    });
+
+    return new Response(null, {
+      status: 302,
+      headers: {
+        Location: "/",
+      },
+    });
+  })
+  .post("/logout", async (c) => {
+    const token = getCookie(c, "session");
+
+    if (token) {
+      const { session } = await validateSessionToken(token);
+      if (session) {
+        await invalidateSession(session.id);
+      }
+    }
+
+    deleteCookie(c, "session", {
+      path: "/",
+    });
+
+    return c.json({ success: true });
   });
 
-  return new Response(null, {
-    status: 302,
-    headers: {
-      Location: "/",
-    },
-  });
-});
+export type AuthRoute = typeof app;
 
 export default app;

--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -4,5 +4,5 @@ import { absoluteUrl } from "./utils";
 export const slack = new Slack(
   process.env.SLACK_APP_CLIENT_ID!,
   process.env.SLACK_APP_CLIENT_SECRET,
-  absoluteUrl("/api/login/slack/callback"),
+  absoluteUrl("/api/auth/slack/callback"),
 );

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -47,3 +47,7 @@ export const getCurrentSession = async () => {
   const result = await validateSessionToken(token);
   return result;
 };
+
+export async function invalidateSession(sessionId: string) {
+  await db.delete(schema.sessions).where(eq(schema.sessions.id, sessionId));
+}


### PR DESCRIPTION
## 対応するIssue

close N/A

## やること

- [x] Headerコンポーネントの作成
  - サービス名とログイン/ユーザーメニューを表示
  - shadcnのAvatarとDropdownMenuコンポーネントを使用
  - ユーザーのイニシャルまたはアバター画像を表示
  - ドロップダウンにユーザー名とメールアドレスを表示
- [x] ランディングページとダッシュボードにヘッダーを追加
  - 背景色を各ページに合わせて設定
- [x] ログアウト機能の実装
  - invalidateSession関数をsession.tsに追加
  - POST /api/auth/logout エンドポイントを作成
  - セッション検証後に無効化処理を実行
  - authClientを使用したログアウト処理
- [x] authルートのリファクタリング
  - /api/login → /api/auth にルートを変更
  - authハンドラーをメソッドチェーンで記述
  - authClientのベースURLを更新
  - 全ての参照を新しい /api/auth パスに更新

## やらないこと

特になし

## スクリーンショット

<!-- 後で追加可能 -->

## 動作確認方法

1. ログイン前：ヘッダーに「ログイン」ボタンが表示される
2. ログイン後：ヘッダーにユーザーアイコンが表示される
3. アイコンをクリック：ドロップダウンメニューが表示される
4. 「ログアウト」をクリック：ログアウトしてトップページにリダイレクト

## その他補足

特になし
