### PR TITLE
feat: add vercel.json to run migrations during Vercel builds

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "buildCommand": "pnpm db:migrate && pnpm build"
+}


### PR DESCRIPTION
## 対応するIssue

close N/A

## やること

- [x] Vercel ビルド時にデータベースマイグレーションを実行するための設定
  - vercel.json を追加し、buildCommand に pnpm db:migrate を含める (4070b5a)

## やらないこと

特になし

## 動作確認方法

- Vercel にデプロイして、ビルドログでマイグレーションが実行されることを確認

## その他補足

### 背景

Vercel のビルド環境ではデータベース接続が可能なため、ビルド前にマイグレーションを実行できます。

### vercel.json の設定内容

`buildCommand` を `pnpm db:migrate && pnpm build` に設定することで：
- Vercel 環境: マイグレーション → ビルドの順で実行
- ローカル/CI 環境: package.json の通常の build スクリプトが実行される（影響なし）
