### PR TITLE
feat: add task status transition validation

### DIFF
--- a/migrations/0007_fast_ultron.sql
+++ b/migrations/0007_fast_ultron.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."task_status" ADD VALUE 'cancelled';

--- a/migrations/meta/0007_snapshot.json
+++ b/migrations/meta/0007_snapshot.json
@@ -1,0 +1,1273 @@
+{
+  "id": "b948ee69-ea1b-43cd-909f-d6214235a816",
+  "prevId": "d9e58895-0aaf-4610-b6ea-ddb9252f1c17",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.access_tokens": {
+      "name": "access_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "access_tokens_token_hash_unique": {
+          "name": "access_tokens_token_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "access_tokens_client_id_clients_id_fk": {
+          "name": "access_tokens_client_id_clients_id_fk",
+          "tableFrom": "access_tokens",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "access_tokens_user_id_users_id_fk": {
+          "name": "access_tokens_user_id_users_id_fk",
+          "tableFrom": "access_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "access_tokens_workspace_id_workspaces_id_fk": {
+          "name": "access_tokens_workspace_id_workspaces_id_fk",
+          "tableFrom": "access_tokens",
+          "tableTo": "workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_codes": {
+      "name": "auth_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_codes_code_unique": {
+          "name": "auth_codes_code_unique",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_codes_client_id_clients_id_fk": {
+          "name": "auth_codes_client_id_clients_id_fk",
+          "tableFrom": "auth_codes",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_codes_user_id_users_id_fk": {
+          "name": "auth_codes_user_id_users_id_fk",
+          "tableFrom": "auth_codes",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_codes_workspace_id_workspaces_id_fk": {
+          "name": "auth_codes_workspace_id_workspaces_id_fk",
+          "tableFrom": "auth_codes",
+          "tableTo": "workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clients": {
+      "name": "clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "clients_client_id_unique": {
+          "name": "clients_client_id_unique",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_id": {
+          "name": "access_token_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "refresh_tokens_token_hash_unique": {
+          "name": "refresh_tokens_token_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_access_token_idx": {
+          "name": "refresh_tokens_access_token_idx",
+          "columns": [
+            {
+              "expression": "access_token_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_user_idx": {
+          "name": "refresh_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_access_token_id_access_tokens_id_fk": {
+          "name": "refresh_tokens_access_token_id_access_tokens_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "access_tokens",
+          "columnsFrom": ["access_token_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "refresh_tokens_client_id_clients_id_fk": {
+          "name": "refresh_tokens_client_id_clients_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "refresh_tokens_workspace_id_workspaces_id_fk": {
+          "name": "refresh_tokens_workspace_id_workspaces_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_completions": {
+      "name": "task_completions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_session_id": {
+          "name": "task_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_completions_task_session_unique": {
+          "name": "task_completions_task_session_unique",
+          "columns": [
+            {
+              "expression": "task_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_completions_task_session_id_task_sessions_id_fk": {
+          "name": "task_completions_task_session_id_task_sessions_id_fk",
+          "tableFrom": "task_completions",
+          "tableTo": "task_sessions",
+          "columnsFrom": ["task_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_events": {
+      "name": "task_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_session_id": {
+          "name": "task_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "task_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_context": {
+          "name": "raw_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_events_task_session_idx": {
+          "name": "task_events_task_session_idx",
+          "columns": [
+            {
+              "expression": "task_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_events_event_type_idx": {
+          "name": "task_events_event_type_idx",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_events_task_session_event_type_idx": {
+          "name": "task_events_task_session_event_type_idx",
+          "columns": [
+            {
+              "expression": "task_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_events_task_session_id_task_sessions_id_fk": {
+          "name": "task_events_task_session_id_task_sessions_id_fk",
+          "tableFrom": "task_events",
+          "tableTo": "task_sessions",
+          "columnsFrom": ["task_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_sessions": {
+      "name": "task_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_provider": {
+          "name": "issue_provider",
+          "type": "issue_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_title": {
+          "name": "issue_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initial_summary": {
+          "name": "initial_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "task_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'in_progress'"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_channel": {
+          "name": "slack_channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_sessions_user_idx": {
+          "name": "task_sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_sessions_issue_provider_idx": {
+          "name": "task_sessions_issue_provider_idx",
+          "columns": [
+            {
+              "expression": "issue_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_sessions_status_idx": {
+          "name": "task_sessions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_sessions_user_id_users_id_fk": {
+          "name": "task_sessions_user_id_users_id_fk",
+          "tableFrom": "task_sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_sessions_workspace_id_workspaces_id_fk": {
+          "name": "task_sessions_workspace_id_workspaces_id_fk",
+          "tableFrom": "task_sessions",
+          "tableTo": "workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_updates": {
+      "name": "task_updates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_session_id": {
+          "name": "task_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_context": {
+          "name": "raw_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_updates_task_session_idx": {
+          "name": "task_updates_task_session_idx",
+          "columns": [
+            {
+              "expression": "task_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_updates_task_session_id_task_sessions_id_fk": {
+          "name": "task_updates_task_session_id_task_sessions_id_fk",
+          "tableFrom": "task_updates",
+          "tableTo": "task_sessions",
+          "columnsFrom": ["task_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_id": {
+          "name": "slack_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed_at": {
+          "name": "onboarding_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_slack_id_unique": {
+          "name": "users_slack_id_unique",
+          "columns": [
+            {
+              "expression": "slack_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_members": {
+      "name": "workspace_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_members_workspace_user_unique": {
+          "name": "workspace_members_workspace_user_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_members_workspace_idx": {
+          "name": "workspace_members_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_members_user_idx": {
+          "name": "workspace_members_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_members_workspace_id_workspaces_id_fk": {
+          "name": "workspace_members_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_members",
+          "tableTo": "workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_members_user_id_users_id_fk": {
+          "name": "workspace_members_user_id_users_id_fk",
+          "tableFrom": "workspace_members",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspaces": {
+      "name": "workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "workspace_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_access_token": {
+          "name": "bot_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_refresh_token": {
+          "name": "bot_refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_token_expires_at": {
+          "name": "bot_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_channel_id": {
+          "name": "notification_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_channel_name": {
+          "name": "notification_channel_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspaces_provider_external_unique": {
+          "name": "workspaces_provider_external_unique",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.issue_provider": {
+      "name": "issue_provider",
+      "schema": "public",
+      "values": ["github", "manual"]
+    },
+    "public.task_event_type": {
+      "name": "task_event_type",
+      "schema": "public",
+      "values": [
+        "started",
+        "updated",
+        "blocked",
+        "block_resolved",
+        "paused",
+        "resumed",
+        "completed"
+      ]
+    },
+    "public.task_status": {
+      "name": "task_status",
+      "schema": "public",
+      "values": ["in_progress", "blocked", "paused", "completed", "cancelled"]
+    },
+    "public.workspace_provider": {
+      "name": "workspace_provider",
+      "schema": "public",
+      "values": ["slack"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1764529727088,
       "tag": "0006_stormy_whiplash",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1764532227963,
+      "tag": "0007_fast_ultron",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -26,6 +26,7 @@ export const taskStatusEnum = pgEnum("task_status", [
   "blocked",
   "paused",
   "completed",
+  "cancelled",
 ]);
 
 export const workspaceProviderEnum = pgEnum("workspace_provider", ["slack"]);

--- a/src/domain/task-status.test.ts
+++ b/src/domain/task-status.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import {
+  ALLOWED_TRANSITIONS,
+  isTerminalStatus,
+  isValidTransition,
+  validateTransition,
+  type TaskStatus,
+} from "./task-status";
+
+describe("task-status", () => {
+  describe("ALLOWED_TRANSITIONS", () => {
+    it("should define valid transitions for in_progress", () => {
+      expect(ALLOWED_TRANSITIONS.in_progress).toEqual([
+        "blocked",
+        "paused",
+        "completed",
+        "cancelled",
+      ]);
+    });
+
+    it("should define valid transitions for blocked", () => {
+      expect(ALLOWED_TRANSITIONS.blocked).toEqual([
+        "in_progress",
+        "paused",
+        "cancelled",
+      ]);
+    });
+
+    it("should define valid transitions for paused", () => {
+      expect(ALLOWED_TRANSITIONS.paused).toEqual(["in_progress", "cancelled"]);
+    });
+
+    it("should define no transitions for completed (terminal state)", () => {
+      expect(ALLOWED_TRANSITIONS.completed).toEqual([]);
+    });
+
+    it("should define no transitions for cancelled (terminal state)", () => {
+      expect(ALLOWED_TRANSITIONS.cancelled).toEqual([]);
+    });
+  });
+
+  describe("isValidTransition", () => {
+    it("should allow same state transition", () => {
+      const statuses: TaskStatus[] = [
+        "in_progress",
+        "blocked",
+        "paused",
+        "completed",
+        "cancelled",
+      ];
+
+      statuses.forEach((status) => {
+        expect(isValidTransition(status, status)).toBe(true);
+      });
+    });
+
+    it("should allow valid transitions from in_progress", () => {
+      expect(isValidTransition("in_progress", "blocked")).toBe(true);
+      expect(isValidTransition("in_progress", "paused")).toBe(true);
+      expect(isValidTransition("in_progress", "completed")).toBe(true);
+      expect(isValidTransition("in_progress", "cancelled")).toBe(true);
+    });
+
+    it("should allow valid transitions from blocked", () => {
+      expect(isValidTransition("blocked", "in_progress")).toBe(true);
+      expect(isValidTransition("blocked", "paused")).toBe(true);
+      expect(isValidTransition("blocked", "cancelled")).toBe(true);
+    });
+
+    it("should allow valid transitions from paused", () => {
+      expect(isValidTransition("paused", "in_progress")).toBe(true);
+      expect(isValidTransition("paused", "cancelled")).toBe(true);
+    });
+
+    it("should reject invalid transitions from blocked", () => {
+      expect(isValidTransition("blocked", "completed")).toBe(false);
+    });
+
+    it("should reject invalid transitions from paused", () => {
+      expect(isValidTransition("paused", "blocked")).toBe(false);
+      expect(isValidTransition("paused", "completed")).toBe(false);
+    });
+
+    it("should reject all transitions from completed (terminal state)", () => {
+      expect(isValidTransition("completed", "in_progress")).toBe(false);
+      expect(isValidTransition("completed", "blocked")).toBe(false);
+      expect(isValidTransition("completed", "paused")).toBe(false);
+      expect(isValidTransition("completed", "cancelled")).toBe(false);
+    });
+
+    it("should reject all transitions from cancelled (terminal state)", () => {
+      expect(isValidTransition("cancelled", "in_progress")).toBe(false);
+      expect(isValidTransition("cancelled", "blocked")).toBe(false);
+      expect(isValidTransition("cancelled", "paused")).toBe(false);
+      expect(isValidTransition("cancelled", "completed")).toBe(false);
+    });
+  });
+
+  describe("validateTransition", () => {
+    it("should not throw for valid transitions", () => {
+      expect(() => validateTransition("in_progress", "blocked")).not.toThrow();
+      expect(() => validateTransition("blocked", "in_progress")).not.toThrow();
+      expect(() => validateTransition("paused", "in_progress")).not.toThrow();
+    });
+
+    it("should not throw for same state transition", () => {
+      expect(() =>
+        validateTransition("in_progress", "in_progress"),
+      ).not.toThrow();
+      expect(() => validateTransition("completed", "completed")).not.toThrow();
+    });
+
+    it("should throw descriptive error for invalid transitions", () => {
+      expect(() => validateTransition("blocked", "completed")).toThrow(
+        "Invalid status transition: blocked → completed. Allowed transitions from blocked: [in_progress, paused, cancelled]",
+      );
+
+      expect(() => validateTransition("paused", "blocked")).toThrow(
+        "Invalid status transition: paused → blocked. Allowed transitions from paused: [in_progress, cancelled]",
+      );
+
+      expect(() => validateTransition("completed", "in_progress")).toThrow(
+        "Invalid status transition: completed → in_progress. Allowed transitions from completed: []",
+      );
+
+      expect(() => validateTransition("cancelled", "in_progress")).toThrow(
+        "Invalid status transition: cancelled → in_progress. Allowed transitions from cancelled: []",
+      );
+    });
+  });
+
+  describe("isTerminalStatus", () => {
+    it("should return true for terminal states", () => {
+      expect(isTerminalStatus("completed")).toBe(true);
+      expect(isTerminalStatus("cancelled")).toBe(true);
+    });
+
+    it("should return false for non-terminal states", () => {
+      expect(isTerminalStatus("in_progress")).toBe(false);
+      expect(isTerminalStatus("blocked")).toBe(false);
+      expect(isTerminalStatus("paused")).toBe(false);
+    });
+  });
+});

--- a/src/domain/task-status.ts
+++ b/src/domain/task-status.ts
@@ -1,0 +1,57 @@
+import type { TaskSession } from "@/db/schema";
+
+export type TaskStatus = TaskSession["status"];
+
+/**
+ * 許可される状態遷移のマップ
+ * - in_progress: 作業中 → 詰まり/休止/完了/中止へ遷移可能
+ * - blocked: 詰まり → 作業再開/休止/中止へ遷移可能
+ * - paused: 休止 → 作業再開/中止へ遷移可能
+ * - completed: 完了 (終端状態、遷移不可)
+ * - cancelled: 中止 (終端状態、遷移不可)
+ */
+export const ALLOWED_TRANSITIONS: Record<TaskStatus, TaskStatus[]> = {
+  in_progress: ["blocked", "paused", "completed", "cancelled"],
+  blocked: ["in_progress", "paused", "cancelled"],
+  paused: ["in_progress", "cancelled"],
+  completed: [], // 終端状態
+  cancelled: [], // 終端状態
+};
+
+/**
+ * 状態遷移が有効かどうかを検証する
+ * @param from 現在の状態
+ * @param to 遷移先の状態
+ * @returns 有効な遷移の場合true、そうでない場合false
+ */
+export function isValidTransition(from: TaskStatus, to: TaskStatus): boolean {
+  // 同じ状態への遷移は常に許可
+  if (from === to) {
+    return true;
+  }
+
+  return ALLOWED_TRANSITIONS[from].includes(to);
+}
+
+/**
+ * 状態遷移を検証し、無効な場合はエラーをスローする
+ * @param from 現在の状態
+ * @param to 遷移先の状態
+ * @throws {Error} 無効な遷移の場合
+ */
+export function validateTransition(from: TaskStatus, to: TaskStatus): void {
+  if (!isValidTransition(from, to)) {
+    throw new Error(
+      `Invalid status transition: ${from} → ${to}. Allowed transitions from ${from}: [${ALLOWED_TRANSITIONS[from].join(", ")}]`,
+    );
+  }
+}
+
+/**
+ * 終端状態（それ以上遷移できない状態）かどうかを判定する
+ * @param status チェックする状態
+ * @returns 終端状態の場合true
+ */
+export function isTerminalStatus(status: TaskStatus): boolean {
+  return ALLOWED_TRANSITIONS[status].length === 0;
+}

--- a/src/repos/taskSessions.ts
+++ b/src/repos/taskSessions.ts
@@ -73,13 +73,14 @@ type ListTaskSessionsInput = {
 };
 
 const STATUS: Record<
-  "inProgress" | "blocked" | "paused" | "completed",
+  "inProgress" | "blocked" | "paused" | "completed" | "cancelled",
   TaskStatus
 > = {
   inProgress: "in_progress",
   blocked: "blocked",
   paused: "paused",
   completed: "completed",
+  cancelled: "cancelled",
 };
 
 const ensureRecord = <T>(record: T | undefined): T => {

--- a/src/usecases/taskSessions/complete.ts
+++ b/src/usecases/taskSessions/complete.ts
@@ -1,6 +1,7 @@
 import { Env } from "@/app/create-app";
 import { createNotificationService } from "@/services/notificationService";
 import { createTaskRepository } from "@/repos";
+import { validateTransition } from "@/domain/task-status";
 
 export type CompleteTask = {
   task_session_id: string;
@@ -19,6 +20,19 @@ export const completeTask = async (
     workspace,
     taskRepository,
   );
+
+  // 現在のタスクセッションを取得して状態遷移を検証
+  const currentSession = await taskRepository.findTaskSessionById(
+    task_session_id,
+    workspace.id,
+  );
+
+  if (!currentSession) {
+    throw new Error("タスクセッションが見つかりません");
+  }
+
+  // → completed への遷移を検証
+  validateTransition(currentSession.status, "completed");
 
   const { session, completion, unresolvedBlocks } =
     await taskRepository.completeTask({

--- a/src/usecases/taskSessions/pause.ts
+++ b/src/usecases/taskSessions/pause.ts
@@ -1,6 +1,7 @@
 import { Env } from "@/app/create-app";
 import { createNotificationService } from "@/services/notificationService";
 import { createTaskRepository } from "@/repos";
+import { validateTransition } from "@/domain/task-status";
 
 export type PauseTask = {
   task_session_id: string;
@@ -17,6 +18,19 @@ export const pauseTask = async (params: PauseTask, ctx: Env["Variables"]) => {
     workspace,
     taskRepository,
   );
+
+  // 現在のタスクセッションを取得して状態遷移を検証
+  const currentSession = await taskRepository.findTaskSessionById(
+    task_session_id,
+    workspace.id,
+  );
+
+  if (!currentSession) {
+    throw new Error("タスクセッションが見つかりません");
+  }
+
+  // → paused への遷移を検証
+  validateTransition(currentSession.status, "paused");
 
   const { session, pauseReport } = await taskRepository.pauseTask({
     taskSessionId: task_session_id,

--- a/src/usecases/taskSessions/reportBlocked.ts
+++ b/src/usecases/taskSessions/reportBlocked.ts
@@ -1,6 +1,7 @@
 import { Env } from "@/app/create-app";
 import { createNotificationService } from "@/services/notificationService";
 import { createTaskRepository } from "@/repos";
+import { validateTransition } from "@/domain/task-status";
 
 export type ReportBlocked = {
   task_session_id: string;
@@ -20,6 +21,19 @@ export const reportBlocked = async (
     workspace,
     taskRepository,
   );
+
+  // 現在のタスクセッションを取得して状態遷移を検証
+  const currentSession = await taskRepository.findTaskSessionById(
+    task_session_id,
+    workspace.id,
+  );
+
+  if (!currentSession) {
+    throw new Error("タスクセッションが見つかりません");
+  }
+
+  // → blocked への遷移を検証
+  validateTransition(currentSession.status, "blocked");
 
   const { session, blockReport } = await taskRepository.reportBlock({
     taskSessionId: task_session_id,

--- a/src/usecases/taskSessions/resume.ts
+++ b/src/usecases/taskSessions/resume.ts
@@ -1,6 +1,7 @@
 import { Env } from "@/app/create-app";
 import { createNotificationService } from "@/services/notificationService";
 import { createTaskRepository } from "@/repos";
+import { validateTransition } from "@/domain/task-status";
 
 export type ResumeTask = {
   task_session_id: string;
@@ -17,6 +18,19 @@ export const resumeTask = async (params: ResumeTask, ctx: Env["Variables"]) => {
     workspace,
     taskRepository,
   );
+
+  // 現在のタスクセッションを取得して状態遷移を検証
+  const currentSession = await taskRepository.findTaskSessionById(
+    task_session_id,
+    workspace.id,
+  );
+
+  if (!currentSession) {
+    throw new Error("タスクセッションが見つかりません");
+  }
+
+  // paused → in_progress への遷移を検証
+  validateTransition(currentSession.status, "in_progress");
 
   const { session } = await taskRepository.resumeTask({
     taskSessionId: task_session_id,

--- a/src/usecases/taskSessions/update.ts
+++ b/src/usecases/taskSessions/update.ts
@@ -1,6 +1,7 @@
 import { Env } from "@/app/create-app";
 import { createNotificationService } from "@/services/notificationService";
 import { createTaskRepository } from "@/repos";
+import { validateTransition } from "@/domain/task-status";
 
 export type UpdateTask = {
   task_session_id: string;
@@ -17,6 +18,19 @@ export const updateTask = async (params: UpdateTask, ctx: Env["Variables"]) => {
     workspace,
     taskRepository,
   );
+
+  // 現在のタスクセッションを取得して状態遷移を検証
+  const currentSession = await taskRepository.findTaskSessionById(
+    task_session_id,
+    workspace.id,
+  );
+
+  if (!currentSession) {
+    throw new Error("タスクセッションが見つかりません");
+  }
+
+  // blocked/paused → in_progress への遷移を検証
+  validateTransition(currentSession.status, "in_progress");
 
   const { session, update } = await taskRepository.addTaskUpdate({
     taskSessionId: task_session_id,


### PR DESCRIPTION
## 対応するIssue

close N/A

## やること

- [x] タスク状態遷移のドメインロジック実装
  - 状態遷移ルール（ALLOWED_TRANSITIONS）の定義
  - バリデーション関数（validateTransition, isValidTransition）の実装
  - ヘルパー関数（isTerminalStatus）の実装
- [x] cancelled ステータスの追加
  - スキーマに cancelled を追加
  - リポジトリ層の STATUS 定数を更新
- [x] ユースケース層に状態遷移バリデーションを適用
  - update: blocked/paused → in_progress の検証
  - reportBlocked: → blocked の検証
  - pause: → paused の検証
  - resume: paused → in_progress の検証
  - complete: → completed の検証
  - resolveBlocked: blocked → in_progress の検証
- [x] ドメインロジックのテスト追加（19テスト）
  - 状態遷移ルールのテスト
  - バリデーションロジックのテスト
  - 終端状態判定のテスト
- [x] マイグレーション生成
  - PostgreSQL enum型に cancelled を追加

## やらないこと

- cancel_task MCPツールの追加（別PRで実装予定）

## その他補足

### 実装方針

クリーンアーキテクチャに則り、以下の層で実装しました：

- **ドメイン層** (`src/domain/task-status.ts`): 状態遷移ルールとバリデーションロジック
- **ユースケース層** (`src/usecases/taskSessions/*.ts`): ドメインロジックを使用した状態遷移検証
- **リポジトリ層** (`src/repos/taskSessions.ts`): データアクセスのみ（バリデーションなし）

### 状態遷移ルール

- `in_progress` → `blocked`, `paused`, `completed`, `cancelled`
- `blocked` → `in_progress`, `paused`, `cancelled`
- `paused` → `in_progress`, `cancelled`
- `completed` → （終端状態、遷移不可）
- `cancelled` → （終端状態、遷移不可）

### テスト結果

- ✅ 型チェック: 成功
- ✅ ビルド: 成功  
- ✅ テスト: 19/19 passed
