### PR TITLE
feat: プラン別セッション制限の実装

### DIFF
--- a/src/repos/index.ts
+++ b/src/repos/index.ts
@@ -1,3 +1,4 @@
 export * from "./taskSessions";
 export * from "./workspaces";
 export * from "./users";
+export * from "./subscriptions";

--- a/src/services/subscriptionService.ts
+++ b/src/services/subscriptionService.ts
@@ -1,0 +1,31 @@
+import type { SubscriptionRepository } from "@/repos/subscriptions";
+
+const FREE_PLAN_LIMIT = 5;
+
+/**
+ * 無料プランの制限をチェック
+ * @returns エラーメッセージ。制限内ならnull
+ */
+export async function checkFreePlanLimit(
+  userId: string,
+  subscriptionRepo: SubscriptionRepository,
+): Promise<string | null> {
+  // アクティブなサブスクリプションがあるかチェック
+  const activeSubscription =
+    await subscriptionRepo.getActiveSubscription(userId);
+
+  // サブスクリプションがあれば制限なし
+  if (activeSubscription) {
+    return null;
+  }
+
+  // 無料プランの場合、セッション数をチェック
+  const sessionCount = await subscriptionRepo.countUserTaskSessions(userId);
+
+  if (sessionCount >= FREE_PLAN_LIMIT) {
+    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000";
+    return `無料プランの制限（${FREE_PLAN_LIMIT}セッション）に達しました。引き続きご利用いただくには、有料プランへのアップグレードをお願いします。\n詳細: ${baseUrl}/pricing`;
+  }
+
+  return null;
+}


### PR DESCRIPTION
## 対応するIssue

close N/A

## やること

- [x] サブスクリプションリポジトリの作成
  - アクティブなサブスクリプション取得機能
  - タスクセッション数カウント機能
- [x] プラン制限チェックサービスの実装
  - 無料プラン: 5セッションまで
  - 有料プラン: 無制限
  - 制限超過時のエラーメッセージ（決済ページURLを含む）
- [x] MCP start_task での制限チェック統合
  - タスク作成前にプラン制限をチェック
  - 制限超過時はエラーレスポンスを返却

## やらないこと

- 既存タスクセッションへの影響（完了済みタスクのカウント方法の最適化など）

## スクリーンショット

N/A

## 動作確認方法

1. MCPクライアントから `start_task` を6回実行
2. 6回目で制限エラーが返却されることを確認
3. 有料プランのユーザーで制限がないことを確認

## その他補足

- リポジトリパターンに従い、DB操作をリポジトリ層に集約
- サービス層にリポジトリを注入する形で疎結合を実現
- 環境変数 `NEXT_PUBLIC_BASE_URL` から決済ページURLを生成
