### PR TITLE
feat: add Stripe webhook endpoint resource to prod environment

### DIFF
--- a/infra/enviroments/prod/main.tf
+++ b/infra/enviroments/prod/main.tf
@@ -16,3 +16,15 @@ resource "stripe_price" "basic_monthly_price" {
     interval_count = 1
   }
 }
+
+# Stripe Webhook Endpoint
+resource "stripe_webhook_endpoint" "webhook" {
+  url         = "${var.webhook_base_url}/api/stripe/webhook"
+  description = "Webhook endpoint for subscription and customer events"
+  enabled_events = [
+    "customer.subscription.created",
+    "customer.subscription.updated",
+    "customer.subscription.deleted",
+    "customer.deleted"
+  ]
+}

--- a/infra/enviroments/prod/outputs.tf
+++ b/infra/enviroments/prod/outputs.tf
@@ -9,3 +9,15 @@ output "stripe_product_id" {
   value       = stripe_product.basic_product.id
   sensitive   = false
 }
+
+output "stripe_webhook_id" {
+  description = "Stripe Webhook Endpoint ID"
+  value       = stripe_webhook_endpoint.webhook.id
+  sensitive   = false
+}
+
+output "stripe_webhook_secret" {
+  description = "Stripe Webhook Secret (use this for STRIPE_WEBHOOK_SECRET env variable)"
+  value       = stripe_webhook_endpoint.webhook.secret
+  sensitive   = true
+}

--- a/infra/enviroments/prod/terraform.tfvars.example
+++ b/infra/enviroments/prod/terraform.tfvars.example
@@ -8,3 +8,7 @@ project_name = "ava"
 # 本番環境では sk_live_ で始まるライブモードのAPIキーを使用してください
 # 例: export TF_VAR_stripe_api_key=sk_live_xxxxx
 # stripe_api_key = "sk_live_xxxxx"
+
+# Webhook のベース URL (本番環境のドメイン)
+# 例: webhook_base_url = "https://yourdomain.com"
+webhook_base_url = "https://yourdomain.com"

--- a/infra/enviroments/prod/variables.tf
+++ b/infra/enviroments/prod/variables.tf
@@ -12,3 +12,8 @@ variable "stripe_api_key" {
   type        = string
   sensitive   = true
 }
+
+variable "webhook_base_url" {
+  description = "Webhook のベース URL (例: https://yourdomain.com)"
+  type        = string
+}


### PR DESCRIPTION
## 対応するIssue

close N/A

## やること

- [x] Stripe Webhook エンドポイントリソースの追加
  - [x]  リソースを prod 環境に追加 (45402ec)
  - [x]  変数を追加して設定可能に
  - [x] Webhook ID と Secret の Output を追加
  - [x] terraform.tfvars.example に webhook_base_url の設定例を追加

## やらないこと

- dev 環境への同様の設定追加（必要に応じて別PRで対応）

## 動作確認方法

1.  に実際のドメインを設定
   ```hcl
   webhook_base_url = "https://your-domain.com"
   ```

2. Webhook エンドポイントのみを apply
   ```bash
   cd infra/enviroments/prod
   ../../tf.sh apply -target=stripe_webhook_endpoint.webhook
   ```

3. Webhook Secret を取得して環境変数に設定
   ```bash
   ../../tf.sh output -raw stripe_webhook_secret
   ```

## その他補足

このPRで追加される Webhook は以下のイベントを処理します：
- `customer.subscription.created`
- `customer.subscription.updated`
- `customer.subscription.deleted`
- `customer.deleted`

これらは既存の `src/handlers/api/stripe.ts` で実装済みのイベントハンドラーに対応しています。
