### PR TITLE
feat: hash OAuth client secrets with SHA-256

### DIFF
--- a/src/handlers/api/oauth.test.ts
+++ b/src/handlers/api/oauth.test.ts
@@ -154,13 +154,16 @@ describe("api/oauth", () => {
       testUser = user;
       testWorkspace = workspace;
 
-      // Create test client
+      // Create test client (hash the client secret)
+      const clientSecretHash = encodeHexLowerCase(
+        sha256(new TextEncoder().encode("test-client-secret")),
+      );
       const [client] = await db
         .insert(schema.clients)
         .values({
           id: uuidv7(),
           clientId: "test-client-id",
-          clientSecret: "test-client-secret",
+          clientSecret: clientSecretHash,
           name: "Test Client",
           redirectUris: ["https://example.com/callback"],
         })
@@ -516,9 +519,12 @@ describe("api/oauth", () => {
     it("should handle URL-encoded characters in client_secret_basic", async () => {
       // Create a client with special characters in secret
       const specialSecret = "test:secret@123";
+      const specialSecretHash = encodeHexLowerCase(
+        sha256(new TextEncoder().encode(specialSecret)),
+      );
       await db
         .update(schema.clients)
-        .set({ clientSecret: specialSecret })
+        .set({ clientSecret: specialSecretHash })
         .where(eq(schema.clients.id, testClient.id));
 
       // Update auth code to match
@@ -558,9 +564,12 @@ describe("api/oauth", () => {
     it("should handle multiple colons in client_secret", async () => {
       // Create a client with multiple colons in secret
       const secretWithColons = "secret:with:multiple:colons:here";
+      const secretWithColonsHash = encodeHexLowerCase(
+        sha256(new TextEncoder().encode(secretWithColons)),
+      );
       await db
         .update(schema.clients)
-        .set({ clientSecret: secretWithColons })
+        .set({ clientSecret: secretWithColonsHash })
         .where(eq(schema.clients.id, testClient.id));
 
       // Create new auth code
@@ -845,13 +854,16 @@ describe("api/oauth", () => {
     });
 
     it("should fail when using auth code with different client_id", async () => {
-      // Create another client
+      // Create another client (hash the client secret)
+      const otherClientSecretHash = encodeHexLowerCase(
+        sha256(new TextEncoder().encode("other-client-secret")),
+      );
       const [otherClient] = await db
         .insert(schema.clients)
         .values({
           id: uuidv7(),
           clientId: "other-client-id",
-          clientSecret: "other-client-secret",
+          clientSecret: otherClientSecretHash,
           name: "Other Client",
           redirectUris: ["https://example.com/callback"],
         })
@@ -1005,13 +1017,16 @@ describe("api/oauth", () => {
       testUser = user;
       testWorkspace = workspace;
 
-      // Create test client
+      // Create test client (hash the client secret)
+      const clientSecretHash = encodeHexLowerCase(
+        sha256(new TextEncoder().encode("test-client-secret")),
+      );
       const [client] = await db
         .insert(schema.clients)
         .values({
           id: uuidv7(),
           clientId: "test-client-id",
-          clientSecret: "test-client-secret",
+          clientSecret: clientSecretHash,
           name: "Test Client",
           redirectUris: ["https://example.com/callback"],
         })


### PR DESCRIPTION
## 対応するIssue

close N/A

## やること

- [x] OAuth クライアントシークレットのハッシュ化
  - クライアント登録時に SHA-256 でハッシュ化して DB に保存
  - トークン検証時に提供されたシークレットをハッシュ化して比較
  - タイミング攻撃対策を継続（timing-safe comparison）
- [x] テストの更新
  - テストデータ作成時にシークレットをハッシュ化
  - 全 49 件のテストが成功

## やらないこと

特になし

## スクリーンショット

N/A（バックエンドのみの変更）

## 動作確認方法

1. テストを実行: `pnpm test src/handlers/api/oauth.test.ts`
2. 型チェック: `pnpm typecheck`

## その他補足

### セキュリティの改善
- セッショントークンと同じ SHA-256 不可逆ハッシュ方式を採用
- DB に保存されるのはハッシュ値のみ（平文のシークレットは保存しない）
- クライアント登録時のレスポンスでは平文シークレットを返却（クライアントが保存できるように）

### 実装の詳細
- `src/handlers/api/oauth.ts`: クライアント登録 (L388-392) とトークン検証 (L117-123, L289-295) を更新
- `src/handlers/api/oauth.test.ts`: 全テストケースでハッシュ化されたシークレットを使用

### テスト結果
- ✅ 全 49 件のテスト成功
- ✅ 型チェック成功
- ✅ pre-commit フック成功（prettier, eslint）
