### PR TITLE
feat: add Slack thread links to dashboard and task detail pages

### DIFF
--- a/src/app/(private)/dashboard/page.tsx
+++ b/src/app/(private)/dashboard/page.tsx
@@ -12,9 +12,11 @@ import { Badge } from "@/components/ui/badge";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Header } from "@/components/header";
 import Link from "next/link";
+import { MessageSquare } from "lucide-react";
 import { formatDate, formatDuration } from "@/utils/date";
 import { requireWorkspace } from "@/lib/auth";
 import { getInitials } from "@/lib/utils";
+import { buildSlackThreadUrl } from "@/utils/slack";
 
 function StatusBadge({ status }: { status: string }) {
   const variants = {
@@ -114,35 +116,57 @@ export default async function DashboardPage() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {tasksWithDuration.map((task) => (
-                  <TableRow
-                    key={task.id}
-                    className="cursor-pointer hover:bg-slate-50"
-                  >
-                    <TableCell className="font-medium max-w-md">
-                      <Link href={`/tasks/${task.id}`} className="block">
-                        <div className="truncate hover:text-blue-600">
-                          {task.issueTitle}
-                        </div>
-                        <div className="text-xs text-slate-500 truncate mt-1">
-                          {task.initialSummary}
-                        </div>
-                      </Link>
-                    </TableCell>
-                    <TableCell>
-                      <StatusBadge status={task.status} />
-                    </TableCell>
-                    <TableCell className="text-slate-600">
-                      {formatDate(task.createdAt)}
-                    </TableCell>
-                    <TableCell className="text-slate-600">
-                      {task.completedAt ? formatDate(task.completedAt) : "-"}
-                    </TableCell>
-                    <TableCell className="text-right font-mono text-slate-900">
-                      {task.durationMs ? formatDuration(task.durationMs) : "-"}
-                    </TableCell>
-                  </TableRow>
-                ))}
+                {tasksWithDuration.map((task) => {
+                  const slackThreadUrl = buildSlackThreadUrl({
+                    workspaceExternalId: workspace.externalId,
+                    workspaceDomain: workspace.domain,
+                    channelId: task.slackChannel,
+                    threadTs: task.slackThreadTs,
+                  });
+
+                  return (
+                    <TableRow
+                      key={task.id}
+                      className="cursor-pointer hover:bg-slate-50"
+                    >
+                      <TableCell className="font-medium max-w-md">
+                        <Link href={`/tasks/${task.id}`} className="block">
+                          <div className="truncate hover:text-blue-600">
+                            {task.issueTitle}
+                          </div>
+                          <div className="text-xs text-slate-500 truncate mt-1">
+                            {task.initialSummary}
+                          </div>
+                        </Link>
+                        {slackThreadUrl && (
+                          <Link
+                            href={slackThreadUrl}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="mt-2 inline-flex items-center gap-1 text-xs text-blue-600 hover:text-blue-700 hover:underline"
+                          >
+                            <MessageSquare className="h-3 w-3" />
+                            Slackスレッド
+                          </Link>
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        <StatusBadge status={task.status} />
+                      </TableCell>
+                      <TableCell className="text-slate-600">
+                        {formatDate(task.createdAt)}
+                      </TableCell>
+                      <TableCell className="text-slate-600">
+                        {task.completedAt ? formatDate(task.completedAt) : "-"}
+                      </TableCell>
+                      <TableCell className="text-right font-mono text-slate-900">
+                        {task.durationMs
+                          ? formatDuration(task.durationMs)
+                          : "-"}
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
               </TableBody>
             </Table>
           )}

--- a/src/app/(private)/tasks/[id]/page.tsx
+++ b/src/app/(private)/tasks/[id]/page.tsx
@@ -5,9 +5,17 @@ import { Header } from "@/components/header";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import Link from "next/link";
-import { ArrowLeft, Clock, Calendar, GitBranch } from "lucide-react";
+import {
+  ArrowLeft,
+  Clock,
+  Calendar,
+  GitBranch,
+  MessageSquare,
+} from "lucide-react";
 import { formatDate, formatDuration } from "@/utils/date";
 import { requireWorkspace } from "@/lib/auth";
+import { Button } from "@/components/ui/button";
+import { buildSlackThreadUrl } from "@/utils/slack";
 
 function StatusBadge({ status }: { status: string }) {
   const variants = {
@@ -101,6 +109,16 @@ export default async function TaskDetailPage({ params }: PageProps) {
     }
   }
 
+  const slackThreadUrl = buildSlackThreadUrl({
+    workspaceExternalId: workspace.externalId,
+    workspaceDomain: workspace.domain,
+    channelId: task.slackChannel,
+    threadTs: task.slackThreadTs,
+  });
+
+  const slackChannelLabel =
+    workspace.notificationChannelName ?? task.slackChannel ?? null;
+
   return (
     <div className="min-h-screen bg-slate-50">
       <Header user={user} className="bg-slate-50" />
@@ -186,6 +204,40 @@ export default async function TaskDetailPage({ params }: PageProps) {
             </Card>
           )}
         </div>
+
+        <Card className="mb-8">
+          <CardHeader className="flex items-center justify-between gap-4">
+            <CardTitle className="flex items-center gap-2">
+              <MessageSquare className="w-5 h-5" />
+              Slackスレッド
+            </CardTitle>
+            {slackThreadUrl && (
+              <Button asChild variant="outline" size="sm">
+                <Link href={slackThreadUrl} target="_blank" rel="noreferrer">
+                  Slackで開く
+                </Link>
+              </Button>
+            )}
+          </CardHeader>
+          <CardContent>
+            {slackThreadUrl ? (
+              <div className="space-y-2 text-sm text-slate-600">
+                {slackChannelLabel && (
+                  <p className="font-medium text-slate-900">
+                    投稿先: {slackChannelLabel}
+                  </p>
+                )}
+                <p className="text-xs text-slate-500 break-all">
+                  スレッドTS: {task.slackThreadTs}
+                </p>
+              </div>
+            ) : (
+              <p className="text-sm text-slate-600">
+                Slackへのスレッド情報がまだありません。Slack通知が有効になるとここにリンクが表示されます。
+              </p>
+            )}
+          </CardContent>
+        </Card>
 
         {completionSummary && (
           <Card className="mb-8">

--- a/src/utils/slack.test.ts
+++ b/src/utils/slack.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { buildSlackThreadUrl } from "./slack";
+
+describe("utils/slack", () => {
+  describe("buildSlackThreadUrl", () => {
+    it("app.slack.com形式のスレッドURLを生成できる", () => {
+      const url = buildSlackThreadUrl({
+        workspaceExternalId: "T12345678",
+        channelId: "C98765432",
+        threadTs: "1700000000.123456",
+      });
+
+      expect(url).toBe(
+        "https://app.slack.com/client/T12345678/C98765432/thread/C98765432-1700000000.123456",
+      );
+    });
+
+    it("ドメイン情報からパーマリンクを生成できる", () => {
+      const url = buildSlackThreadUrl({
+        workspaceDomain: "example",
+        channelId: "C98765432",
+        threadTs: "1700000000.123456",
+      });
+
+      expect(url).toBe(
+        "https://example.slack.com/archives/C98765432/p1700000000123456?thread_ts=1700000000.123456&cid=C98765432",
+      );
+    });
+
+    it("必要な情報が欠けている場合はnullを返す", () => {
+      expect(
+        buildSlackThreadUrl({
+          workspaceExternalId: "T123",
+          channelId: null,
+          threadTs: "1700000000.123456",
+        }),
+      ).toBeNull();
+
+      expect(
+        buildSlackThreadUrl({
+          workspaceExternalId: "T123",
+          channelId: "C987",
+          threadTs: null,
+        }),
+      ).toBeNull();
+    });
+  });
+});

--- a/src/utils/slack.ts
+++ b/src/utils/slack.ts
@@ -1,0 +1,38 @@
+type SlackThreadUrlParams = {
+  workspaceExternalId?: string | null;
+  workspaceDomain?: string | null;
+  channelId?: string | null;
+  threadTs?: string | null;
+};
+
+/**
+ * Slackのスレッドを開くためのURLを生成する。
+ * workspaceExternalId があれば app.slack.com 形式を優先し、
+ * ない場合はドメイン形式のパーマリンクを返す。
+ */
+export function buildSlackThreadUrl(
+  params: SlackThreadUrlParams,
+): string | null {
+  const { workspaceExternalId, workspaceDomain, channelId, threadTs } = params;
+
+  if (!channelId || !threadTs) {
+    return null;
+  }
+
+  if (workspaceExternalId) {
+    const encodedWorkspace = encodeURIComponent(workspaceExternalId);
+    const encodedChannel = encodeURIComponent(channelId);
+    const encodedThreadTs = encodeURIComponent(threadTs);
+
+    return `https://app.slack.com/client/${encodedWorkspace}/${encodedChannel}/thread/${encodedChannel}-${encodedThreadTs}`;
+  }
+
+  if (workspaceDomain) {
+    const tsFragment = threadTs.replace(/\./g, "");
+    const encodedChannel = encodeURIComponent(channelId);
+    const encodedThreadTs = encodeURIComponent(threadTs);
+    return `https://${workspaceDomain}.slack.com/archives/${encodedChannel}/p${tsFragment}?thread_ts=${encodedThreadTs}&cid=${encodedChannel}`;
+  }
+
+  return null;
+}


### PR DESCRIPTION
## 対応するIssue

close N/A

## やること

- [x] Slack スレッド URL 生成ユーティリティの追加
  - buildSlackThreadUrl 関数の実装（app.slack.com 形式とドメイン形式の両方に対応）
  - ユニットテストの追加
- [x] ダッシュボードにSlackスレッドリンクを追加
  - タスク一覧の各タスクにSlackスレッドへのリンクを表示
- [x] タスク詳細ページにSlackスレッドカードを追加
  - Slackスレッド情報を表示するカードセクションを追加
  - チャンネル名とスレッドTSを表示
  - 「Slackで開く」ボタンを追加

## やらないこと

特になし

## スクリーンショット

<\!-- レビュー時に追加予定 -->

## 動作確認方法

1. Slack連携済みのワークスペースでタスクを作成
2. ダッシュボードでタスク一覧にSlackスレッドリンクが表示されることを確認
3. タスク詳細ページでSlackスレッドカードが表示されることを確認
4. リンクをクリックしてSlackの該当スレッドが開くことを確認

## その他補足

- workspaceExternalId がある場合は app.slack.com 形式を優先
- ない場合は workspace domain を使用したパーマリンク形式にフォールバック
- チャンネルIDまたはスレッドTSが欠けている場合は null を返す安全な実装
