### PR TITLE
feat: add GitHub link to siteConfig and HTML standard link types

### DIFF
--- a/content/docs/privacy.mdx
+++ b/content/docs/privacy.mdx
@@ -121,4 +121,4 @@ description: Avaのプライバシーポリシーをご確認ください。
 
 ## 9. お問い合わせ
 
-プライバシーに関するお問い合わせは、[GitHubリポジトリ](https://github.com/yutakobayashidev/ai-task)にてお願いいたします。
+プライバシーに関するお問い合わせは、[GitHubリポジトリ](https://github.com/yutakobayashidev/ava)にてお願いいたします。

--- a/content/docs/terms.mdx
+++ b/content/docs/terms.mdx
@@ -58,4 +58,4 @@ description: Avaの利用規約をご確認ください。
 
 ## 9. お問い合わせ
 
-本規約に関するお問い合わせは、[GitHubリポジトリ](https://github.com/yutakobayashidev/ai-task)にてお願いいたします。
+本規約に関するお問い合わせは、[GitHubリポジトリ](https://github.com/yutakobayashidev/ava)にてお願いいたします。

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,6 +10,10 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: LayoutProps<"/">) {
   return (
     <html lang="ja" suppressHydrationWarning>
+      <head>
+        <link rel="privacy-policy" href="/docs/privacy" />
+        <link rel="terms-of-service" href="/docs/terms" />
+      </head>
       <body>{children}</body>
     </html>
   );

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -61,7 +61,7 @@ export default function NotFound() {
               </Link>
               をご確認いただくか、
               <a
-                href="https://github.com/yutakobayashidev/ai-task"
+                href={siteConfig.github}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-primary hover:underline font-medium ml-1"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -571,12 +571,14 @@ export default async function LandingPage() {
               </Link>
               <Link
                 href="/docs/terms"
+                rel="terms-of-service"
                 className="hover:text-white transition-colors"
               >
                 利用規約
               </Link>
               <Link
                 href="/docs/privacy"
+                rel="privacy-policy"
                 className="hover:text-white transition-colors"
               >
                 プライバシーポリシー
@@ -588,7 +590,7 @@ export default async function LandingPage() {
                 特定商取引法に基づく表記
               </Link>
               <a
-                href="https://github.com/yutakobayashidev/ai-task"
+                href={siteConfig.github}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="hover:text-white transition-colors"

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -2,7 +2,8 @@ export const siteConfig = {
   name: process.env.NEXT_PUBLIC_SITE_NAME,
   description:
     "集中作業に最適化されたタスク管理。コーディングエージェントが自動的に進捗をSlackに同期—コンテキストスイッチ不要。フロー状態を保つために作られました。",
-};
+  github: "https://github.com/yutakobayashidev/ava",
+} as const;
 
 export type SiteConfig = typeof siteConfig;
 


### PR DESCRIPTION
## 対応するIssue

close N/A

## やること

- [x] siteConfigにGitHubリンクを追加
  - GitHubリポジトリのURLを一元管理するため、siteConfigにgithubフィールドを追加
- [x] 既存のGitHubリンクをsiteConfig.githubに統一
  - page.tsxとnot-found.tsxのハードコードされたGitHubリンクをsiteConfig.githubに置き換え
- [x] ドキュメント内のリポジトリ名を更新
  - privacy.mdxとterms.mdxのGitHubリンクをai-taskからavaに変更
- [x] HTML標準のlink typeを追加
  - layout.tsxに<link rel="privacy-policy">と<link rel="terms-of-service">を追加
  - page.tsxのフッターリンクにrel属性を追加（RFC6903準拠）

## やらないこと

特になし

## スクリーンショット

特になし（メタデータの変更のみ）

## 動作確認方法

特になし

## その他補足

HTML標準のlink type（RFC6903）を追加することで、プライバシーポリシーと利用規約のリンク関係を機械可読な形で表現しています。
