### PR TITLE
refactor: extract Stripe subscription to reusable Terraform module

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -11,3 +11,7 @@
 
 - Terraform の静的解析は `./infra/tflint.sh <command>` から実行してください。初回は自動的に `tflint --init` まで実行されます。
 - 例: `./infra/tflint.sh`（全体 lint）、`./infra/tflint.sh --module supabase`（モジュール単位の lint）。
+
+## Modules
+
+- `infra/modules/stripe-subscription` に Stripe のプロダクト・プライス・Webhook をまとめた共通モジュールがあります。環境ごとの設定は `enviroments/*/main.tf` からこのモジュールを呼び出してください。

--- a/infra/enviroments/dev/main.tf
+++ b/infra/enviroments/dev/main.tf
@@ -1,18 +1,3 @@
-# Stripe Subscription Plans
-
-resource "stripe_product" "basic_product" {
-  name        = "Basic Plan"
-  description = "Basic subscription plan"
-  active      = true
-}
-
-resource "stripe_price" "basic_monthly_price" {
-  product     = stripe_product.basic_product.id
-  currency    = "jpy"
-  unit_amount = 500
-  lookup_key  = "basic_monthly"
-  recurring {
-    interval       = "month"
-    interval_count = 1
-  }
+module "stripe_subscription" {
+  source = "../../modules/stripe-subscription"
 }

--- a/infra/enviroments/dev/outputs.tf
+++ b/infra/enviroments/dev/outputs.tf
@@ -1,11 +1,11 @@
 output "stripe_price_id" {
   description = "Stripe Price ID for Basic Plan (monthly subscription)"
-  value       = stripe_price.basic_monthly_price.id
+  value       = module.stripe_subscription.price_id
   sensitive   = false
 }
 
 output "stripe_product_id" {
   description = "Stripe Product ID for Basic Plan"
-  value       = stripe_product.basic_product.id
+  value       = module.stripe_subscription.product_id
   sensitive   = false
 }

--- a/infra/enviroments/prod/main.tf
+++ b/infra/enviroments/prod/main.tf
@@ -1,23 +1,7 @@
-# Stripe Subscription Plans
-
-resource "stripe_product" "basic_product" {
-  name        = "Basic Plan"
-  description = "Basic subscription plan"
-  active      = true
+module "stripe_subscription" {
+  source = "../../modules/stripe-subscription"
 }
 
-resource "stripe_price" "basic_monthly_price" {
-  product     = stripe_product.basic_product.id
-  currency    = "jpy"
-  unit_amount = 500
-  lookup_key  = "basic_monthly"
-  recurring {
-    interval       = "month"
-    interval_count = 1
-  }
-}
-
-# Stripe Webhook Endpoint
 resource "stripe_webhook_endpoint" "webhook" {
   url         = "${var.webhook_base_url}/api/stripe/webhook"
   description = "Webhook endpoint for subscription and customer events"
@@ -25,6 +9,6 @@ resource "stripe_webhook_endpoint" "webhook" {
     "customer.subscription.created",
     "customer.subscription.updated",
     "customer.subscription.deleted",
-    "customer.deleted"
+    "customer.deleted",
   ]
 }

--- a/infra/enviroments/prod/outputs.tf
+++ b/infra/enviroments/prod/outputs.tf
@@ -1,12 +1,12 @@
 output "stripe_price_id" {
   description = "Stripe Price ID for Basic Plan (monthly subscription)"
-  value       = stripe_price.basic_monthly_price.id
+  value       = module.stripe_subscription.price_id
   sensitive   = false
 }
 
 output "stripe_product_id" {
   description = "Stripe Product ID for Basic Plan"
-  value       = stripe_product.basic_product.id
+  value       = module.stripe_subscription.product_id
   sensitive   = false
 }
 

--- a/infra/modules/stripe-subscription/README.md
+++ b/infra/modules/stripe-subscription/README.md
@@ -1,0 +1,43 @@
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.13.5 |
+| <a name="requirement_stripe"></a> [stripe](#requirement\_stripe) | ~> 1.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_stripe"></a> [stripe](#provider\_stripe) | ~> 1.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [stripe_price.price](https://registry.terraform.io/providers/lukasaron/stripe/latest/docs/resources/price) | resource |
+| [stripe_product.product](https://registry.terraform.io/providers/lukasaron/stripe/latest/docs/resources/product) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_price_currency"></a> [price\_currency](#input\_price\_currency) | Currency for the Stripe price | `string` | `"jpy"` | no |
+| <a name="input_price_interval"></a> [price\_interval](#input\_price\_interval) | Recurring interval for the Stripe price | `string` | `"month"` | no |
+| <a name="input_price_interval_count"></a> [price\_interval\_count](#input\_price\_interval\_count) | Number of intervals between recurring payments | `number` | `1` | no |
+| <a name="input_price_lookup_key"></a> [price\_lookup\_key](#input\_price\_lookup\_key) | Lookup key for the Stripe price | `string` | `"basic_monthly"` | no |
+| <a name="input_price_unit_amount"></a> [price\_unit\_amount](#input\_price\_unit\_amount) | Unit amount for the Stripe price (in the smallest currency unit) | `number` | `500` | no |
+| <a name="input_product_active"></a> [product\_active](#input\_product\_active) | Whether the Stripe product is active | `bool` | `true` | no |
+| <a name="input_product_description"></a> [product\_description](#input\_product\_description) | Stripe product description | `string` | `"Basic subscription plan"` | no |
+| <a name="input_product_name"></a> [product\_name](#input\_product\_name) | Stripe product name | `string` | `"Basic Plan"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_price_id"></a> [price\_id](#output\_price\_id) | Stripe Price ID |
+| <a name="output_product_id"></a> [product\_id](#output\_product\_id) | Stripe Product ID |

--- a/infra/modules/stripe-subscription/main.tf
+++ b/infra/modules/stripe-subscription/main.tf
@@ -1,0 +1,17 @@
+resource "stripe_product" "product" {
+  name        = var.product_name
+  description = var.product_description
+  active      = var.product_active
+}
+
+resource "stripe_price" "price" {
+  product     = stripe_product.product.id
+  currency    = var.price_currency
+  unit_amount = var.price_unit_amount
+  lookup_key  = var.price_lookup_key
+
+  recurring {
+    interval       = var.price_interval
+    interval_count = var.price_interval_count
+  }
+}

--- a/infra/modules/stripe-subscription/outputs.tf
+++ b/infra/modules/stripe-subscription/outputs.tf
@@ -1,0 +1,9 @@
+output "product_id" {
+  description = "Stripe Product ID"
+  value       = stripe_product.product.id
+}
+
+output "price_id" {
+  description = "Stripe Price ID"
+  value       = stripe_price.price.id
+}

--- a/infra/modules/stripe-subscription/provider.tf
+++ b/infra/modules/stripe-subscription/provider.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.13.5"
+  required_providers {
+    stripe = {
+      source  = "lukasaron/stripe"
+      version = "~> 1.0"
+    }
+  }
+}

--- a/infra/modules/stripe-subscription/variables.tf
+++ b/infra/modules/stripe-subscription/variables.tf
@@ -1,0 +1,51 @@
+variable "product_name" {
+  description = "Stripe product name"
+  type        = string
+  default     = "Basic Plan"
+}
+
+variable "product_description" {
+  description = "Stripe product description"
+  type        = string
+  default     = "Basic subscription plan"
+}
+
+variable "product_active" {
+  description = "Whether the Stripe product is active"
+  type        = bool
+  default     = true
+}
+
+variable "price_currency" {
+  description = "Currency for the Stripe price"
+  type        = string
+  default     = "jpy"
+}
+
+variable "price_unit_amount" {
+  description = "Unit amount for the Stripe price (in the smallest currency unit)"
+  type        = number
+  default     = 500
+}
+
+variable "price_lookup_key" {
+  description = "Lookup key for the Stripe price"
+  type        = string
+  default     = "basic_monthly"
+}
+
+variable "price_interval" {
+  description = "Recurring interval for the Stripe price"
+  type        = string
+  default     = "month"
+  validation {
+    condition     = contains(["day", "week", "month", "year"], var.price_interval)
+    error_message = "Interval must be one of day, week, month, or year."
+  }
+}
+
+variable "price_interval_count" {
+  description = "Number of intervals between recurring payments"
+  type        = number
+  default     = 1
+}


### PR DESCRIPTION
## 対応するIssue

close N/A

## やること

- [x] Stripe サブスクリプションの Terraform モジュール化
  - [refactor: extract Stripe subscription to reusable Terraform module](https://github.com/yutakobayashidev/ai-task/commit/3a868d7)
    - `infra/modules/stripe-subscription` モジュールを作成
    - dev と prod 環境を新しいモジュールを使用するように移行
    - outputs をモジュールの outputs を参照するように更新
    - `infra/README.md` にモジュールのドキュメントを追加

## やらないこと

- prod 環境の Webhook エンドポイントのモジュール化（今回は Stripe サブスクリプションリソースのみを対象）

## その他補足

Stripe の Product と Price リソースが dev/prod で重複していたため、再利用可能なモジュールとして抽出しました。これにより:

- コードの重複を削減
- 環境間で一貫した設定を維持しやすくなる
- 将来的に他の環境やプロジェクトでも再利用可能

モジュールには適切なデフォルト値と validation を設定しており、必要に応じてカスタマイズ可能です。
