### PR TITLE
fix: user avatar not displaying

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -19,7 +19,7 @@ import { getInitials } from "@/lib/utils";
 type User = {
   name?: string | null;
   email?: string | null;
-  imageUrl?: string | null;
+  image?: string | null;
 };
 
 type HeaderProps = {
@@ -56,7 +56,7 @@ export function Header({ user, className = "bg-white" }: HeaderProps) {
                 >
                   <Avatar className="h-10 w-10">
                     <AvatarImage
-                      src={user.imageUrl ?? undefined}
+                      src={user.image ?? undefined}
                       alt={user.name ?? ""}
                     />
                     <AvatarFallback>


### PR DESCRIPTION
## 対応するIssue

close N/A

## やること

- [x] header.tsxのUser型定義をDBスキーマに合わせて修正
  - imageUrlをimageに変更してユーザーアイコンが表示されるように修正

## やらないこと

特になし

## スクリーンショット

（見た目の変更確認が必要）

## 動作確認方法

1. ログイン後、ヘッダーのユーザーアイコンが正しく表示されることを確認

## その他補足

DBスキーマ（src/db/schema.ts）のusersテーブルでは`image`カラムを使用していますが、header.tsxでは`imageUrl`を参照していたため、ユーザーアイコンが表示されませんでした。この不整合を修正しました。