### PR TITLE
feat: add camelCase conversion for MCP server arguments

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "ai": "5.0.104",
     "arctic": "3.7.0",
     "babel-plugin-react-compiler": "1.0.0",
+    "camelcase-keys": "10.0.1",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
     "cmdk": "1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,6 +128,9 @@ importers:
       babel-plugin-react-compiler:
         specifier: 1.0.0
         version: 1.0.0
+      camelcase-keys:
+        specifier: 10.0.1
+        version: 10.0.1
       class-variance-authority:
         specifier: 0.7.1
         version: 0.7.1
@@ -3002,6 +3005,14 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
+  camelcase-keys@10.0.1:
+    resolution: {integrity: sha512-kIH5nQUKB8ORZrwjk40GUgnhzuzxwKb6n5L+anOVmVSrjgix1pfNqVNl0tEcOP4AaFYdke3NNpNiGDSD112lcA==}
+    engines: {node: '>=20'}
+
+  camelcase@8.0.0:
+    resolution: {integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==}
+    engines: {node: '>=16'}
+
   caniuse-lite@1.0.30001757:
     resolution: {integrity: sha512-r0nnL/I28Zi/yjk1el6ilj27tKcdjLsNqAOZr0yVjWPrSQyHgKI2INaEWw21bAQSv2LXRt1XuCS/GomNpWOxsQ==}
 
@@ -4563,6 +4574,10 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
+  map-obj@5.0.2:
+    resolution: {integrity: sha512-K6K2NgKnTXimT3779/4KxSvobxOtMmx1LBZ3NwRxT/MDIR3Br/fQ4Q+WCX5QxjyUR8zg5+RV9Tbf2c5pAWTD2A==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   markdown-extensions@2.0.0:
     resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
     engines: {node: '>=16'}
@@ -5106,6 +5121,10 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  quick-lru@7.3.0:
+    resolution: {integrity: sha512-k9lSsjl36EJdK7I06v7APZCbyGT2vMTsYSRX1Q2nbYmnkBqgUhRkAuzH08Ciotteu/PLJmIF2+tti7o3C/ts2g==}
+    engines: {node: '>=18'}
 
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
@@ -5719,6 +5738,10 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  type-fest@4.41.0:
+    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
+    engines: {node: '>=16'}
 
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
@@ -8623,6 +8646,15 @@ snapshots:
 
   callsites@3.1.0: {}
 
+  camelcase-keys@10.0.1:
+    dependencies:
+      camelcase: 8.0.0
+      map-obj: 5.0.2
+      quick-lru: 7.3.0
+      type-fest: 4.41.0
+
+  camelcase@8.0.0: {}
+
   caniuse-lite@1.0.30001757: {}
 
   ccount@2.0.1: {}
@@ -10368,6 +10400,8 @@ snapshots:
     dependencies:
       semver: 7.7.3
 
+  map-obj@5.0.2: {}
+
   markdown-extensions@2.0.0: {}
 
   markdown-table@3.0.4: {}
@@ -11179,6 +11213,8 @@ snapshots:
       side-channel: 1.1.0
 
   queue-microtask@1.2.3: {}
+
+  quick-lru@7.3.0: {}
 
   range-parser@1.2.1: {}
 
@@ -11998,6 +12034,8 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  type-fest@4.41.0: {}
 
   type-is@2.0.1:
     dependencies:

--- a/src/handlers/mcp-server.ts
+++ b/src/handlers/mcp-server.ts
@@ -1,35 +1,27 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod/v3";
+import camelcaseKeys from "camelcase-keys";
 import type { Env } from "@/app/create-app";
 import * as taskSessionUsecases from "@/usecases/taskSessions";
+
+const rawContextSchema = z
+  .record(z.string(), z.unknown())
+  .default({})
+  .describe("Slackへ共有可能な抽象的メタデータ");
+
+const issueSchema = z.object({
+  provider: z.enum(["github", "manual"]).describe("課題の取得元"),
+  id: z.string().trim().optional().describe("GitHub Issue番号などの識別子"),
+  title: z
+    .string()
+    .min(1, "タイトルは必須です")
+    .describe("タスクの簡潔なタイトル"),
+});
 
 export function createMcpServer(ctx: Env["Variables"]) {
   const server = new McpServer({
     name: "ava-mcp",
     version: "1.0.0",
-  });
-
-  const toTextResponse = (text: string) => ({
-    content: [
-      {
-        type: "text" as const,
-        text,
-      },
-    ],
-  });
-
-  const rawContextSchema = z
-    .record(z.string(), z.unknown())
-    .default({})
-    .describe("Slackへ共有可能な抽象的メタデータ");
-
-  const issueSchema = z.object({
-    provider: z.enum(["github", "manual"]).describe("課題の取得元"),
-    id: z.string().trim().optional().describe("GitHub Issue番号などの識別子"),
-    title: z
-      .string()
-      .min(1, "タイトルは必須です")
-      .describe("タスクの簡潔なタイトル"),
   });
 
   server.registerTool(
@@ -45,12 +37,17 @@ export function createMcpServer(ctx: Env["Variables"]) {
           .describe("着手時点の抽象的な状況や方針"),
       }),
     },
-    async ({ issue, initial_summary }) => {
-      const result = await taskSessionUsecases.startTasks(
-        { issue, initial_summary },
-        ctx,
-      );
-      return toTextResponse(result.success ? result.data : result.error);
+    async (args) => {
+      const camelArgs = camelcaseKeys(args, { deep: true });
+      const result = await taskSessionUsecases.startTasks(camelArgs, ctx);
+      return {
+        content: [
+          {
+            type: "text",
+            text: result.success ? result.data : result.error,
+          },
+        ],
+      };
     },
   );
 
@@ -71,12 +68,17 @@ export function createMcpServer(ctx: Env["Variables"]) {
         raw_context: rawContextSchema,
       }),
     },
-    async ({ task_session_id, summary, raw_context }) => {
-      const result = await taskSessionUsecases.updateTask(
-        { task_session_id, summary, raw_context },
-        ctx,
-      );
-      return toTextResponse(result.success ? result.data : result.error);
+    async (args) => {
+      const camelArgs = camelcaseKeys(args, { deep: true });
+      const result = await taskSessionUsecases.updateTask(camelArgs, ctx);
+      return {
+        content: [
+          {
+            type: "text",
+            text: result.success ? result.data : result.error,
+          },
+        ],
+      };
     },
   );
 
@@ -97,12 +99,17 @@ export function createMcpServer(ctx: Env["Variables"]) {
         raw_context: rawContextSchema,
       }),
     },
-    async ({ task_session_id, reason, raw_context }) => {
-      const result = await taskSessionUsecases.reportBlocked(
-        { task_session_id, reason, raw_context },
-        ctx,
-      );
-      return toTextResponse(result.success ? result.data : result.error);
+    async (args) => {
+      const camelArgs = camelcaseKeys(args, { deep: true });
+      const result = await taskSessionUsecases.reportBlocked(camelArgs, ctx);
+      return {
+        content: [
+          {
+            type: "text",
+            text: result.success ? result.data : result.error,
+          },
+        ],
+      };
     },
   );
 
@@ -123,12 +130,17 @@ export function createMcpServer(ctx: Env["Variables"]) {
         raw_context: rawContextSchema,
       }),
     },
-    async ({ task_session_id, reason, raw_context }) => {
-      const result = await taskSessionUsecases.pauseTask(
-        { task_session_id, reason, raw_context },
-        ctx,
-      );
-      return toTextResponse(result.success ? result.data : result.error);
+    async (args) => {
+      const camelArgs = camelcaseKeys(args, { deep: true });
+      const result = await taskSessionUsecases.pauseTask(camelArgs, ctx);
+      return {
+        content: [
+          {
+            type: "text",
+            text: result.success ? result.data : result.error,
+          },
+        ],
+      };
     },
   );
 
@@ -149,12 +161,17 @@ export function createMcpServer(ctx: Env["Variables"]) {
         raw_context: rawContextSchema,
       }),
     },
-    async ({ task_session_id, summary, raw_context }) => {
-      const result = await taskSessionUsecases.resumeTask(
-        { task_session_id, summary, raw_context },
-        ctx,
-      );
-      return toTextResponse(result.success ? result.data : result.error);
+    async (args) => {
+      const camelArgs = camelcaseKeys(args, { deep: true });
+      const result = await taskSessionUsecases.resumeTask(camelArgs, ctx);
+      return {
+        content: [
+          {
+            type: "text",
+            text: result.success ? result.data : result.error,
+          },
+        ],
+      };
     },
   );
 
@@ -174,12 +191,17 @@ export function createMcpServer(ctx: Env["Variables"]) {
           .describe("完了内容の抽象的サマリ"),
       }),
     },
-    async ({ task_session_id, summary }) => {
-      const result = await taskSessionUsecases.completeTask(
-        { task_session_id, summary },
-        ctx,
-      );
-      return toTextResponse(result.success ? result.data : result.error);
+    async (args) => {
+      const camelArgs = camelcaseKeys(args, { deep: true });
+      const result = await taskSessionUsecases.completeTask(camelArgs, ctx);
+      return {
+        content: [
+          {
+            type: "text",
+            text: result.success ? result.data : result.error,
+          },
+        ],
+      };
     },
   );
 
@@ -201,12 +223,17 @@ export function createMcpServer(ctx: Env["Variables"]) {
           ),
       }),
     },
-    async ({ task_session_id, block_report_id }) => {
-      const result = await taskSessionUsecases.resolveBlocked(
-        { task_session_id, block_report_id },
-        ctx,
-      );
-      return toTextResponse(result.success ? result.data : result.error);
+    async (args) => {
+      const camelArgs = camelcaseKeys(args, { deep: true });
+      const result = await taskSessionUsecases.resolveBlocked(camelArgs, ctx);
+      return {
+        content: [
+          {
+            type: "text",
+            text: result.success ? result.data : result.error,
+          },
+        ],
+      };
     },
   );
 
@@ -228,12 +255,17 @@ export function createMcpServer(ctx: Env["Variables"]) {
           .describe("取得する最大件数（デフォルト: 50）"),
       }),
     },
-    async ({ status, limit }) => {
-      const result = await taskSessionUsecases.listTasks(
-        { status, limit },
-        ctx,
-      );
-      return toTextResponse(result.success ? result.data : result.error);
+    async (args) => {
+      const camelArgs = camelcaseKeys(args, { deep: true });
+      const result = await taskSessionUsecases.listTasks(camelArgs, ctx);
+      return {
+        content: [
+          {
+            type: "text",
+            text: result.success ? result.data : result.error,
+          },
+        ],
+      };
     },
   );
 

--- a/src/usecases/taskSessions/complete.ts
+++ b/src/usecases/taskSessions/complete.ts
@@ -4,7 +4,7 @@ import { createTaskRepository, createWorkspaceRepository } from "@/repos";
 import { isValidTransition, ALLOWED_TRANSITIONS } from "@/domain/task-status";
 
 type CompleteTask = {
-  task_session_id: string;
+  taskSessionId: string;
   summary: string;
 };
 
@@ -14,7 +14,7 @@ export const completeTask = async (
 ): Promise<
   { success: true; data: string } | { success: false; error: string }
 > => {
-  const { task_session_id, summary } = params;
+  const { taskSessionId, summary } = params;
 
   const [user, workspace, db] = [ctx.user, ctx.workspace, ctx.db];
   const taskRepository = createTaskRepository({ db });
@@ -27,7 +27,7 @@ export const completeTask = async (
 
   // 現在のタスクセッションを取得して状態遷移を検証
   const currentSession = await taskRepository.findTaskSessionById(
-    task_session_id,
+    taskSessionId,
     workspace.id,
     user.id,
   );
@@ -49,7 +49,7 @@ export const completeTask = async (
 
   const { session, completedEvent, unresolvedBlocks } =
     await taskRepository.completeTask({
-      taskSessionId: task_session_id,
+      taskSessionId: taskSessionId,
       workspaceId: workspace.id,
       userId: user.id,
       summary,

--- a/src/usecases/taskSessions/pause.ts
+++ b/src/usecases/taskSessions/pause.ts
@@ -4,9 +4,9 @@ import { createTaskRepository, createWorkspaceRepository } from "@/repos";
 import { isValidTransition, ALLOWED_TRANSITIONS } from "@/domain/task-status";
 
 type PauseTask = {
-  task_session_id: string;
+  taskSessionId: string;
   reason: string;
-  raw_context?: Record<string, unknown>;
+  rawContext?: Record<string, unknown>;
 };
 
 export const pauseTask = async (
@@ -15,7 +15,7 @@ export const pauseTask = async (
 ): Promise<
   { success: true; data: string } | { success: false; error: string }
 > => {
-  const { task_session_id, reason, raw_context } = params;
+  const { taskSessionId, reason, rawContext } = params;
 
   const [user, workspace, db] = [ctx.user, ctx.workspace, ctx.db];
   const taskRepository = createTaskRepository({ db });
@@ -28,7 +28,7 @@ export const pauseTask = async (
 
   // 現在のタスクセッションを取得して状態遷移を検証
   const currentSession = await taskRepository.findTaskSessionById(
-    task_session_id,
+    taskSessionId,
     workspace.id,
     user.id,
   );
@@ -49,11 +49,11 @@ export const pauseTask = async (
   }
 
   const { session, pauseReport } = await taskRepository.pauseTask({
-    taskSessionId: task_session_id,
+    taskSessionId: taskSessionId,
     workspaceId: workspace.id,
     userId: user.id,
     reason,
-    rawContext: raw_context ?? {},
+    rawContext: rawContext ?? {},
   });
 
   if (!session || !pauseReport) {

--- a/src/usecases/taskSessions/reportBlocked.ts
+++ b/src/usecases/taskSessions/reportBlocked.ts
@@ -4,9 +4,9 @@ import { createTaskRepository, createWorkspaceRepository } from "@/repos";
 import { isValidTransition, ALLOWED_TRANSITIONS } from "@/domain/task-status";
 
 type ReportBlocked = {
-  task_session_id: string;
+  taskSessionId: string;
   reason: string;
-  raw_context?: Record<string, unknown>;
+  rawContext?: Record<string, unknown>;
 };
 
 export const reportBlocked = async (
@@ -15,7 +15,7 @@ export const reportBlocked = async (
 ): Promise<
   { success: true; data: string } | { success: false; error: string }
 > => {
-  const { task_session_id, reason, raw_context } = params;
+  const { taskSessionId, reason, rawContext } = params;
 
   const [user, workspace, db] = [ctx.user, ctx.workspace, ctx.db];
   const taskRepository = createTaskRepository({ db });
@@ -28,7 +28,7 @@ export const reportBlocked = async (
 
   // 現在のタスクセッションを取得して状態遷移を検証
   const currentSession = await taskRepository.findTaskSessionById(
-    task_session_id,
+    taskSessionId,
     workspace.id,
     user.id,
   );
@@ -49,11 +49,11 @@ export const reportBlocked = async (
   }
 
   const { session, blockReport } = await taskRepository.reportBlock({
-    taskSessionId: task_session_id,
+    taskSessionId: taskSessionId,
     workspaceId: workspace.id,
     userId: user.id,
     reason,
-    rawContext: raw_context ?? {},
+    rawContext: rawContext ?? {},
   });
 
   if (!session || !blockReport) {

--- a/src/usecases/taskSessions/resolveBlocked.ts
+++ b/src/usecases/taskSessions/resolveBlocked.ts
@@ -4,8 +4,8 @@ import { createTaskRepository, createWorkspaceRepository } from "@/repos";
 import { isValidTransition, ALLOWED_TRANSITIONS } from "@/domain/task-status";
 
 type ResolveBlocked = {
-  task_session_id: string;
-  block_report_id: string;
+  taskSessionId: string;
+  blockReportId: string;
 };
 
 export const resolveBlocked = async (
@@ -14,7 +14,7 @@ export const resolveBlocked = async (
 ): Promise<
   { success: true; data: string } | { success: false; error: string }
 > => {
-  const { task_session_id, block_report_id } = params;
+  const { taskSessionId, blockReportId } = params;
 
   const [user, workspace, db] = [ctx.user, ctx.workspace, ctx.db];
   const taskRepository = createTaskRepository({ db });
@@ -27,7 +27,7 @@ export const resolveBlocked = async (
 
   // 現在のタスクセッションを取得して状態遷移を検証
   const currentSession = await taskRepository.findTaskSessionById(
-    task_session_id,
+    taskSessionId,
     workspace.id,
     user.id,
   );
@@ -48,10 +48,10 @@ export const resolveBlocked = async (
   }
 
   const { session, blockReport } = await taskRepository.resolveBlockReport({
-    taskSessionId: task_session_id,
+    taskSessionId: taskSessionId,
     workspaceId: workspace.id,
     userId: user.id,
-    blockReportId: block_report_id,
+    blockReportId: blockReportId,
   });
 
   if (!session || !blockReport) {

--- a/src/usecases/taskSessions/resume.ts
+++ b/src/usecases/taskSessions/resume.ts
@@ -4,9 +4,9 @@ import { createTaskRepository, createWorkspaceRepository } from "@/repos";
 import { isValidTransition, ALLOWED_TRANSITIONS } from "@/domain/task-status";
 
 type ResumeTask = {
-  task_session_id: string;
+  taskSessionId: string;
   summary: string;
-  raw_context?: Record<string, unknown>;
+  rawContext?: Record<string, unknown>;
 };
 
 export const resumeTask = async (
@@ -15,7 +15,7 @@ export const resumeTask = async (
 ): Promise<
   { success: true; data: string } | { success: false; error: string }
 > => {
-  const { task_session_id, summary, raw_context } = params;
+  const { taskSessionId, summary, rawContext } = params;
 
   const [user, workspace, db] = [ctx.user, ctx.workspace, ctx.db];
   const taskRepository = createTaskRepository({ db });
@@ -28,7 +28,7 @@ export const resumeTask = async (
 
   // 現在のタスクセッションを取得して状態遷移を検証
   const currentSession = await taskRepository.findTaskSessionById(
-    task_session_id,
+    taskSessionId,
     workspace.id,
     user.id,
   );
@@ -49,11 +49,11 @@ export const resumeTask = async (
   }
 
   const { session } = await taskRepository.resumeTask({
-    taskSessionId: task_session_id,
+    taskSessionId: taskSessionId,
     workspaceId: workspace.id,
     userId: user.id,
     summary,
-    rawContext: raw_context ?? {},
+    rawContext: rawContext ?? {},
   });
 
   if (!session) {

--- a/src/usecases/taskSessions/start.ts
+++ b/src/usecases/taskSessions/start.ts
@@ -13,7 +13,7 @@ type StartTask = {
     id?: string;
     title: string;
   };
-  initial_summary: string;
+  initialSummary: string;
 };
 
 export const startTasks = async (
@@ -22,7 +22,7 @@ export const startTasks = async (
 ): Promise<
   { success: true; data: string } | { success: false; error: string }
 > => {
-  const { issue, initial_summary } = params;
+  const { issue, initialSummary } = params;
 
   const [user, workspace, db] = [ctx.user, ctx.workspace, ctx.db];
 
@@ -50,7 +50,7 @@ export const startTasks = async (
     issueProvider: issue.provider,
     issueId: issue.id ?? null,
     issueTitle: issue.title,
-    initialSummary: initial_summary,
+    initialSummary: initialSummary,
   });
 
   if (!session) {
@@ -67,7 +67,7 @@ export const startTasks = async (
       provider: issue.provider,
       id: issue.id ?? null,
     },
-    initialSummary: initial_summary,
+    initialSummary: initialSummary,
     user: {
       id: user.id,
       name: user.name,

--- a/src/usecases/taskSessions/update.ts
+++ b/src/usecases/taskSessions/update.ts
@@ -4,9 +4,9 @@ import { createTaskRepository, createWorkspaceRepository } from "@/repos";
 import { isValidTransition, ALLOWED_TRANSITIONS } from "@/domain/task-status";
 
 type UpdateTask = {
-  task_session_id: string;
+  taskSessionId: string;
   summary: string;
-  raw_context?: Record<string, unknown>;
+  rawContext?: Record<string, unknown>;
 };
 
 export const updateTask = async (
@@ -15,7 +15,7 @@ export const updateTask = async (
 ): Promise<
   { success: true; data: string } | { success: false; error: string }
 > => {
-  const { task_session_id, summary, raw_context } = params;
+  const { taskSessionId, summary, rawContext } = params;
 
   const [user, workspace, db] = [ctx.user, ctx.workspace, ctx.db];
   const taskRepository = createTaskRepository({ db });
@@ -28,7 +28,7 @@ export const updateTask = async (
 
   // 現在のタスクセッションを取得して状態遷移を検証
   const currentSession = await taskRepository.findTaskSessionById(
-    task_session_id,
+    taskSessionId,
     workspace.id,
     user.id,
   );
@@ -49,11 +49,11 @@ export const updateTask = async (
   }
 
   const { session, updateEvent } = await taskRepository.addTaskUpdate({
-    taskSessionId: task_session_id,
+    taskSessionId: taskSessionId,
     workspaceId: workspace.id,
     userId: user.id,
     summary,
-    rawContext: raw_context ?? {},
+    rawContext: rawContext ?? {},
   });
 
   if (!session || !updateEvent) {


### PR DESCRIPTION
## 対応するIssue

close N/A

## やること

- [x] MCPサーバーの引数をスネークケースからキャメルケースに自動変換
  - camelcase-keysパッケージのインストール
  - 全ツールハンドラーでcamelcaseKeys()を適用（deep: trueオプション付き）
- [x] 全ユースケースの型定義をキャメルケースに統一
  - StartTask: initial_summary → initialSummary
  - UpdateTask, ReportBlocked, PauseTask, ResumeTask: task_session_id → taskSessionId, raw_context → rawContext
  - CompleteTask: task_session_id → taskSessionId
  - ResolveBlocked: task_session_id → taskSessionId, block_report_id → blockReportId
- [x] toTextResponseヘルパー関数の削除
  - 各ハンドラーで直接レスポンスオブジェクトを返すように変更

## やらないこと

特になし

## その他補足

### 技術的な変更点

- MCPプロトコルではスネークケースが一般的ですが、TypeScript/JavaScriptではキャメルケースが標準です
- `camelcase-keys`ライブラリを使用して、MCP層とアプリケーション層の命名規則を透過的に変換します
- `deep: true`オプションにより、ネストされたオブジェクト（raw_contextなど）も再帰的に変換されます
- toTextResponseヘルパーを削除し、各ハンドラーで明示的にレスポンス形式を記述することで、コードの可読性を向上させました
