### PR TITLE
feat: add Google Drive integration for journal export

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,7 @@ OPENAI_API_KEY=sk_
 # Stripe
 STRIPE_SECRET_KEY=sk_test_xxx
 STRIPE_WEBHOOK_SECRET=whsec_xxx
+
+# Google Drive
+GOOGLE_DRIVE_CLIENT_ID=xxx.apps.googleusercontent.com
+GOOGLE_DRIVE_CLIENT_SECRET=xxx

--- a/migrations/0002_thankful_brood.sql
+++ b/migrations/0002_thankful_brood.sql
@@ -1,0 +1,17 @@
+CREATE TABLE "google_drive_connections" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"email" text NOT NULL,
+	"access_token" text NOT NULL,
+	"refresh_token" text NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	"folder_id" text,
+	"folder_name" text,
+	"connected_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "google_drive_connections" ADD CONSTRAINT "google_drive_connections_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "google_drive_connections_user_id_unique" ON "google_drive_connections" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "google_drive_connections_user_idx" ON "google_drive_connections" USING btree ("user_id");

--- a/migrations/meta/0002_snapshot.json
+++ b/migrations/meta/0002_snapshot.json
@@ -1,0 +1,1330 @@
+{
+  "id": "db394fa4-7d01-4b9e-9dc7-9645b12d7459",
+  "prevId": "bfd6c442-aded-4331-8b61-5e66117d8e76",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.access_tokens": {
+      "name": "access_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "access_tokens_token_hash_unique": {
+          "name": "access_tokens_token_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "access_tokens_client_id_clients_id_fk": {
+          "name": "access_tokens_client_id_clients_id_fk",
+          "tableFrom": "access_tokens",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "access_tokens_user_id_users_id_fk": {
+          "name": "access_tokens_user_id_users_id_fk",
+          "tableFrom": "access_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "access_tokens_workspace_id_workspaces_id_fk": {
+          "name": "access_tokens_workspace_id_workspaces_id_fk",
+          "tableFrom": "access_tokens",
+          "tableTo": "workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_codes": {
+      "name": "auth_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_codes_code_unique": {
+          "name": "auth_codes_code_unique",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_codes_client_id_clients_id_fk": {
+          "name": "auth_codes_client_id_clients_id_fk",
+          "tableFrom": "auth_codes",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_codes_user_id_users_id_fk": {
+          "name": "auth_codes_user_id_users_id_fk",
+          "tableFrom": "auth_codes",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_codes_workspace_id_workspaces_id_fk": {
+          "name": "auth_codes_workspace_id_workspaces_id_fk",
+          "tableFrom": "auth_codes",
+          "tableTo": "workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clients": {
+      "name": "clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "clients_client_id_unique": {
+          "name": "clients_client_id_unique",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.google_drive_connections": {
+      "name": "google_drive_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "folder_name": {
+          "name": "folder_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "google_drive_connections_user_id_unique": {
+          "name": "google_drive_connections_user_id_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "google_drive_connections_user_idx": {
+          "name": "google_drive_connections_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "google_drive_connections_user_id_users_id_fk": {
+          "name": "google_drive_connections_user_id_users_id_fk",
+          "tableFrom": "google_drive_connections",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_id": {
+          "name": "access_token_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "refresh_tokens_token_hash_unique": {
+          "name": "refresh_tokens_token_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_access_token_idx": {
+          "name": "refresh_tokens_access_token_idx",
+          "columns": [
+            {
+              "expression": "access_token_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_user_idx": {
+          "name": "refresh_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_access_token_id_access_tokens_id_fk": {
+          "name": "refresh_tokens_access_token_id_access_tokens_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "access_tokens",
+          "columnsFrom": ["access_token_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "refresh_tokens_client_id_clients_id_fk": {
+          "name": "refresh_tokens_client_id_clients_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "refresh_tokens_workspace_id_workspaces_id_fk": {
+          "name": "refresh_tokens_workspace_id_workspaces_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_subscription_id_unique": {
+          "name": "subscriptions_subscription_id_unique",
+          "columns": [
+            {
+              "expression": "subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_user_idx": {
+          "name": "subscriptions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_user_id_users_id_fk": {
+          "name": "subscriptions_user_id_users_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_events": {
+      "name": "task_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_session_id": {
+          "name": "task_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "task_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "related_event_id": {
+          "name": "related_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_context": {
+          "name": "raw_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_events_task_session_idx": {
+          "name": "task_events_task_session_idx",
+          "columns": [
+            {
+              "expression": "task_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_events_event_type_idx": {
+          "name": "task_events_event_type_idx",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_events_task_session_event_type_idx": {
+          "name": "task_events_task_session_event_type_idx",
+          "columns": [
+            {
+              "expression": "task_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_events_task_session_id_task_sessions_id_fk": {
+          "name": "task_events_task_session_id_task_sessions_id_fk",
+          "tableFrom": "task_events",
+          "tableTo": "task_sessions",
+          "columnsFrom": ["task_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_sessions": {
+      "name": "task_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_provider": {
+          "name": "issue_provider",
+          "type": "issue_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_title": {
+          "name": "issue_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initial_summary": {
+          "name": "initial_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "task_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'in_progress'"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_channel": {
+          "name": "slack_channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_sessions_user_idx": {
+          "name": "task_sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_sessions_issue_provider_idx": {
+          "name": "task_sessions_issue_provider_idx",
+          "columns": [
+            {
+              "expression": "issue_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_sessions_status_idx": {
+          "name": "task_sessions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_sessions_user_id_users_id_fk": {
+          "name": "task_sessions_user_id_users_id_fk",
+          "tableFrom": "task_sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_sessions_workspace_id_workspaces_id_fk": {
+          "name": "task_sessions_workspace_id_workspaces_id_fk",
+          "tableFrom": "task_sessions",
+          "tableTo": "workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_id": {
+          "name": "slack_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_team_id": {
+          "name": "slack_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_id": {
+          "name": "stripe_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed_at": {
+          "name": "onboarding_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_slack_id_team_id_unique": {
+          "name": "users_slack_id_team_id_unique",
+          "columns": [
+            {
+              "expression": "slack_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_stripe_id_unique": {
+          "name": "users_stripe_id_unique",
+          "columns": [
+            {
+              "expression": "stripe_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_workspace_id_workspaces_id_fk": {
+          "name": "users_workspace_id_workspaces_id_fk",
+          "tableFrom": "users",
+          "tableTo": "workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspaces": {
+      "name": "workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "workspace_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_access_token": {
+          "name": "bot_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_refresh_token": {
+          "name": "bot_refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_token_expires_at": {
+          "name": "bot_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_channel_id": {
+          "name": "notification_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_channel_name": {
+          "name": "notification_channel_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspaces_provider_external_unique": {
+          "name": "workspaces_provider_external_unique",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.issue_provider": {
+      "name": "issue_provider",
+      "schema": "public",
+      "values": ["github", "manual"]
+    },
+    "public.task_event_type": {
+      "name": "task_event_type",
+      "schema": "public",
+      "values": [
+        "started",
+        "updated",
+        "blocked",
+        "block_resolved",
+        "paused",
+        "resumed",
+        "completed"
+      ]
+    },
+    "public.task_status": {
+      "name": "task_status",
+      "schema": "public",
+      "values": ["in_progress", "blocked", "paused", "completed", "cancelled"]
+    },
+    "public.workspace_provider": {
+      "name": "workspace_provider",
+      "schema": "public",
+      "values": ["slack"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1764695190484,
       "tag": "0001_lean_sunset_bain",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1764781068017,
+      "tag": "0002_thankful_brood",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "fumadocs-core": "16.1.0",
     "fumadocs-mdx": "14.0.3",
     "fumadocs-ui": "16.1.0",
+    "googleapis": "166.0.0",
     "hono": "4.10.7",
     "input-otp": "1.4.2",
     "knip": "5.70.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,6 +158,9 @@ importers:
       fumadocs-ui:
         specifier: 16.1.0
         version: 16.1.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(lucide-react@0.555.0(react@19.2.0))(next@16.0.5(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(tailwindcss@4.1.17)
+      googleapis:
+        specifier: 166.0.0
+        version: 166.0.0
       hono:
         specifier: 4.10.7
         version: 4.10.7
@@ -2942,6 +2945,9 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
@@ -2967,6 +2973,9 @@ packages:
   buffer-crc32@1.0.0:
     resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
     engines: {node: '>=8.0.0'}
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -3203,6 +3212,10 @@ packages:
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
   data-urls@6.0.0:
     resolution: {integrity: sha512-BnBS08aLUM+DKamupXs3w2tJJoqU+AkaE/+6vQxi/G/DPmIZFJJp9Dkb1kM03AZx8ADehDUZgsNxju3mPXZYIA==}
     engines: {node: '>=20'}
@@ -3419,6 +3432,9 @@ packages:
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
@@ -3781,6 +3797,10 @@ packages:
       picomatch:
         optional: true
 
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
@@ -3829,6 +3849,10 @@ packages:
     resolution: {integrity: sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w==}
     engines: {node: '>=18.3.0'}
     hasBin: true
+
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -3934,6 +3958,14 @@ packages:
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
 
+  gaxios@7.1.3:
+    resolution: {integrity: sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@8.1.2:
+    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
+    engines: {node: '>=18'}
+
   generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
     engines: {node: '>= 0.4'}
@@ -3999,6 +4031,22 @@ packages:
   globrex@0.1.2:
     resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
 
+  google-auth-library@10.5.0:
+    resolution: {integrity: sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==}
+    engines: {node: '>=18'}
+
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
+    engines: {node: '>=14'}
+
+  googleapis-common@8.0.1:
+    resolution: {integrity: sha512-eCzNACUXPb1PW5l0ULTzMHaL/ltPRADoPgjBlT8jWsTbxkCp6siv+qKJ/1ldaybCthGwsYFYallF7u9AkU4L+A==}
+    engines: {node: '>=18.0.0'}
+
+  googleapis@166.0.0:
+    resolution: {integrity: sha512-Xz7yG+ihVvYMwSULKIMeTp6vDX95rrSbsaR3xUmgYjwQdAkchMQ5ndFeG5QZwcBOIyvJFvG7ZLIZE7mKW2X/hw==}
+    engines: {node: '>=18'}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -4008,6 +4056,10 @@ packages:
 
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
+
+  gtoken@8.0.0:
+    resolution: {integrity: sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==}
+    engines: {node: '>=18'}
 
   gzip-size@6.0.0:
     resolution: {integrity: sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==}
@@ -4348,6 +4400,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
@@ -4375,6 +4430,12 @@ packages:
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.0:
+    resolution: {integrity: sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -4857,6 +4918,15 @@ packages:
       sass:
         optional: true
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
@@ -5334,6 +5404,10 @@ packages:
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rimraf@5.0.10:
+    resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
+    hasBin: true
 
   rollup@4.53.3:
     resolution: {integrity: sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==}
@@ -5829,6 +5903,9 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  url-template@2.0.8:
+    resolution: {integrity: sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==}
+
   use-callback-ref@1.3.3:
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
     engines: {node: '>=10'}
@@ -5973,6 +6050,10 @@ packages:
   walk-up-path@4.0.0:
     resolution: {integrity: sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==}
     engines: {node: 20 || >=22}
+
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
 
   webidl-conversions@8.0.0:
     resolution: {integrity: sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA==}
@@ -8565,6 +8646,8 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
+  bignumber.js@9.3.1: {}
+
   bl@4.1.0:
     dependencies:
       buffer: 5.7.1
@@ -8607,6 +8690,8 @@ snapshots:
       update-browserslist-db: 1.1.4(browserslist@4.28.0)
 
   buffer-crc32@1.0.0: {}
+
+  buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
 
@@ -8825,6 +8910,8 @@ snapshots:
 
   damerau-levenshtein@1.0.8: {}
 
+  data-uri-to-buffer@4.0.1: {}
+
   data-urls@6.0.0:
     dependencies:
       whatwg-mimetype: 4.0.0
@@ -8963,6 +9050,10 @@ snapshots:
   duplexer@0.1.2: {}
 
   eastasianwidth@0.2.0: {}
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
 
   ee-first@1.1.1: {}
 
@@ -9567,6 +9658,11 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
@@ -9620,6 +9716,10 @@ snapshots:
   formatly@0.3.0:
     dependencies:
       fd-package-json: 2.0.0
+
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
 
   forwarded@0.2.0: {}
 
@@ -9740,6 +9840,23 @@ snapshots:
 
   functions-have-names@1.2.3: {}
 
+  gaxios@7.1.3:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+      rimraf: 5.0.10
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@8.1.2:
+    dependencies:
+      gaxios: 7.1.3
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   generator-function@2.0.1: {}
 
   gensync@1.0.0-beta.2: {}
@@ -9808,11 +9925,49 @@ snapshots:
 
   globrex@0.1.2: {}
 
+  google-auth-library@10.5.0:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.1.3
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      gtoken: 8.0.0
+      jws: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  google-logging-utils@1.1.3: {}
+
+  googleapis-common@8.0.1:
+    dependencies:
+      extend: 3.0.2
+      gaxios: 7.1.3
+      google-auth-library: 10.5.0
+      qs: 6.14.0
+      url-template: 2.0.8
+    transitivePeerDependencies:
+      - supports-color
+
+  googleapis@166.0.0:
+    dependencies:
+      google-auth-library: 10.5.0
+      googleapis-common: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
 
   graphemer@1.4.0: {}
+
+  gtoken@8.0.0:
+    dependencies:
+      gaxios: 7.1.3
+      jws: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   gzip-size@6.0.0:
     dependencies:
@@ -10205,6 +10360,10 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
+
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
@@ -10227,6 +10386,17 @@ snapshots:
       array.prototype.flat: 1.3.3
       object.assign: 4.1.7
       object.values: 1.2.1
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.0:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
 
   keyv@4.5.4:
     dependencies:
@@ -10926,6 +11096,14 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  node-domexception@1.0.0: {}
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
+
   node-releases@2.0.27: {}
 
   normalize-path@3.0.0: {}
@@ -11492,6 +11670,10 @@ snapshots:
   retry@0.13.1: {}
 
   reusify@1.1.0: {}
+
+  rimraf@5.0.10:
+    dependencies:
+      glob: 10.5.0
 
   rollup@4.53.3:
     dependencies:
@@ -12180,6 +12362,8 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  url-template@2.0.8: {}
+
   use-callback-ref@1.3.3(@types/react@19.2.7)(react@19.2.0):
     dependencies:
       react: 19.2.0
@@ -12314,6 +12498,8 @@ snapshots:
       xml-name-validator: 5.0.0
 
   walk-up-path@4.0.0: {}
+
+  web-streams-polyfill@3.3.3: {}
 
   webidl-conversions@8.0.0: {}
 

--- a/src/app/(private)/settings/page.tsx
+++ b/src/app/(private)/settings/page.tsx
@@ -8,8 +8,11 @@ import { requireAuth } from "@/lib/auth";
 import { slackConfig } from "@/lib/slackInstall";
 import { getSlackStatusMessage, isSuccessMessage } from "@/lib/slackMessages";
 import { absoluteUrl } from "@/lib/utils";
-import { createWorkspaceRepository } from "@/repos";
-import { Settings, Slack, Terminal } from "lucide-react";
+import {
+  createWorkspaceRepository,
+  createGoogleDriveConnectionRepository,
+} from "@/repos";
+import { Settings, Slack, Terminal, FolderOpen } from "lucide-react";
 import type { Metadata } from "next";
 import Link from "next/link";
 import { McpSetupTabs } from "../onboarding/setup-mcp/McpSetupTabs";
@@ -26,6 +29,10 @@ export default async function SettingsPage({
   const params = await searchParams;
   const workspaceRepository = createWorkspaceRepository({ db });
   const workspace = await workspaceRepository.findWorkspaceByUser(user.id);
+
+  const googleDriveRepository = createGoogleDriveConnectionRepository({ db });
+  const googleDriveConnection =
+    await googleDriveRepository.findConnectionByUserId(user.id);
 
   const statusMessage = getSlackStatusMessage(params);
   const isSuccess = isSuccessMessage(params);
@@ -169,6 +176,103 @@ export default async function SettingsPage({
                     <Button asChild variant="outline">
                       <Link href="/settings/channel">チャンネル変更</Link>
                     </Button>
+                  </div>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Google Drive連携セクション */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <FolderOpen className="h-5 w-5" />
+                Google Drive連携
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <p className="text-sm text-slate-600">
+                Google Driveに接続して、ジャーナルを自動エクスポートできます。
+              </p>
+
+              <div className="rounded-lg bg-slate-50 border border-slate-200 p-4 space-y-3">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="font-medium text-slate-900">接続状態</p>
+                    {googleDriveConnection ? (
+                      <p className="text-sm text-emerald-600 font-medium">
+                        接続済み
+                      </p>
+                    ) : (
+                      <p className="text-sm text-slate-500">未接続</p>
+                    )}
+                  </div>
+                  <div>
+                    {googleDriveConnection ? (
+                      <Badge variant="default">アクティブ</Badge>
+                    ) : (
+                      <Badge variant="secondary">未設定</Badge>
+                    )}
+                  </div>
+                </div>
+
+                {googleDriveConnection && (
+                  <div className="border-t border-slate-200 pt-3 space-y-2">
+                    <div className="grid grid-cols-2 gap-2 text-sm">
+                      <div>
+                        <p className="text-slate-500">Googleアカウント</p>
+                        <p className="font-medium text-slate-900">
+                          {googleDriveConnection.email}
+                        </p>
+                      </div>
+                      <div>
+                        <p className="text-slate-500">接続日時</p>
+                        <p className="text-xs text-slate-900">
+                          {new Date(
+                            googleDriveConnection.connectedAt,
+                          ).toLocaleDateString()}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              <div className="flex flex-col gap-3">
+                <div className="flex items-center justify-between gap-4">
+                  <div className="flex-1">
+                    <p className="font-medium text-slate-900 text-sm">
+                      アカウントの管理
+                    </p>
+                    <p className="text-xs text-slate-600">
+                      Google Driveへのアクセスを許可
+                    </p>
+                  </div>
+                  <Button asChild>
+                    <Link href="/api/google-drive/connect/start">
+                      {googleDriveConnection ? "再接続" : "接続"}
+                    </Link>
+                  </Button>
+                </div>
+
+                {googleDriveConnection && (
+                  <div className="flex items-center justify-between gap-4">
+                    <div className="flex-1">
+                      <p className="font-medium text-slate-900 text-sm">
+                        ジャーナルのエクスポート
+                      </p>
+                      <p className="text-xs text-slate-600">
+                        本日のタスクをGoogle Driveにエクスポート
+                      </p>
+                    </div>
+                    <form
+                      action="/api/google-drive/export/journal"
+                      method="POST"
+                    >
+                      <Button type="submit" variant="outline">
+                        今すぐエクスポート
+                      </Button>
+                    </form>
                   </div>
                 )}
               </div>

--- a/src/app/api/[...route]/route.ts
+++ b/src/app/api/[...route]/route.ts
@@ -2,6 +2,7 @@ import { handle } from "hono/vercel";
 import oauthRoutes from "@/handlers/api/oauth";
 import authRoutes from "@/handlers/api/auth";
 import slackRoutes from "@/handlers/api/slack";
+import googleDriveRoutes from "@/handlers/api/google-drive";
 import healthRoutes from "@/handlers/api/health";
 import stripeRoutes from "@/handlers/api/stripe";
 import { createHonoApp } from "../../create-app";
@@ -11,6 +12,7 @@ const app = createHonoApp().basePath("/api");
 app.route("/oauth", oauthRoutes);
 app.route("/auth", authRoutes);
 app.route("/slack", slackRoutes);
+app.route("/google-drive", googleDriveRoutes);
 app.route("/stripe", stripeRoutes);
 app.route("/health", healthRoutes);
 

--- a/src/handlers/api/google-drive.ts
+++ b/src/handlers/api/google-drive.ts
@@ -1,0 +1,156 @@
+import { generateState } from "arctic";
+import { deleteCookie, getCookie, setCookie } from "hono/cookie";
+import { zValidator } from "@hono/zod-validator";
+import { z } from "zod";
+
+import { createHonoApp, getUsecaseContext } from "@/app/create-app";
+import { validateSessionToken } from "@/lib/session";
+import { buildGoogleDriveAuthUrl } from "@/lib/googleDrive";
+import { connectGoogleDriveAccount } from "@/usecases/google-drive/connectAccount";
+import { exportJournalToGoogleDrive } from "@/usecases/google-drive/exportJournal";
+import { buildRedirectUrl } from "@/utils/urls";
+import { env } from "hono/adapter";
+
+const app = createHonoApp();
+
+const STATE_COOKIE = "google_drive_state";
+
+app.get("/connect/start", async (ctx) => {
+  const sessionToken = getCookie(ctx, "session");
+
+  const { user } = sessionToken
+    ? await validateSessionToken(sessionToken)
+    : { user: null };
+  if (!user) {
+    return ctx.json({ error: "Unauthorized" }, 401);
+  }
+
+  const state = generateState();
+  const authorizeUrl = buildGoogleDriveAuthUrl(state);
+  const { NODE_ENV } = env(ctx);
+
+  setCookie(ctx, STATE_COOKIE, state, {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: NODE_ENV === "production",
+    path: "/",
+    maxAge: 600,
+  });
+
+  return ctx.redirect(authorizeUrl);
+});
+
+app.get("/connect/callback", async (ctx) => {
+  const sessionToken = getCookie(ctx, "session");
+
+  const { user } = sessionToken
+    ? await validateSessionToken(sessionToken)
+    : { user: null };
+  if (!user) {
+    return ctx.json({ error: "Unauthorized" }, 401);
+  }
+
+  const code = ctx.req.query("code");
+  const state = ctx.req.query("state");
+  const storedState = getCookie(ctx, STATE_COOKIE);
+  const { NODE_ENV } = env(ctx);
+
+  const fallbackPath = "/settings";
+
+  if (!code) {
+    return ctx.redirect(
+      buildRedirectUrl(ctx.req.raw, fallbackPath, {
+        error: "missing_code",
+      }),
+    );
+  }
+
+  if (!storedState || storedState !== state) {
+    return ctx.redirect(
+      buildRedirectUrl(ctx.req.raw, fallbackPath, {
+        error: "state_mismatch",
+      }),
+    );
+  }
+
+  const result = await connectGoogleDriveAccount(
+    {
+      code,
+      userId: user.id,
+    },
+    getUsecaseContext(ctx),
+  );
+
+  // Cookie削除（成功/失敗に関わらず）
+  deleteCookie(ctx, STATE_COOKIE, {
+    path: "/",
+    sameSite: "lax",
+    secure: NODE_ENV === "production",
+  });
+
+  // 結果に応じてリダイレクト
+  if (result.success) {
+    return ctx.redirect(
+      buildRedirectUrl(ctx.req.raw, fallbackPath, {
+        connected: "google_drive",
+        email: result.email,
+      }),
+    );
+  } else {
+    return ctx.redirect(
+      buildRedirectUrl(ctx.req.raw, fallbackPath, {
+        error: result.error,
+      }),
+    );
+  }
+});
+
+app.post(
+  "/export/journal",
+  zValidator(
+    "json",
+    z.object({
+      date: z
+        .string()
+        .regex(/^\d{4}-\d{2}-\d{2}$/)
+        .optional(),
+    }),
+  ),
+  async (ctx) => {
+    const sessionToken = getCookie(ctx, "session");
+
+    const { user } = sessionToken
+      ? await validateSessionToken(sessionToken)
+      : { user: null };
+    if (!user) {
+      return ctx.json({ error: "Unauthorized" }, 401);
+    }
+
+    const { date } = ctx.req.valid("json");
+
+    const result = await exportJournalToGoogleDrive(
+      {
+        userId: user.id,
+        date,
+      },
+      getUsecaseContext(ctx),
+    );
+
+    if (result.success) {
+      return ctx.json({
+        success: true,
+        webViewLink: result.webViewLink,
+      });
+    } else {
+      return ctx.json(
+        {
+          success: false,
+          error: result.error,
+        },
+        400,
+      );
+    }
+  },
+);
+
+export default app;

--- a/src/lib/googleDrive.ts
+++ b/src/lib/googleDrive.ts
@@ -1,0 +1,148 @@
+import "server-only";
+
+import { google } from "googleapis";
+import { absoluteUrl } from "./utils";
+
+const GOOGLE_OAUTH_ENDPOINT = "https://accounts.google.com/o/oauth2/v2/auth";
+
+const DEFAULT_SCOPES = [
+  "https://www.googleapis.com/auth/drive.file",
+  "https://www.googleapis.com/auth/userinfo.email",
+];
+
+export const googleDriveConfig = {
+  clientId: process.env.GOOGLE_DRIVE_CLIENT_ID!,
+  clientSecret: process.env.GOOGLE_DRIVE_CLIENT_SECRET!,
+  redirectUri: absoluteUrl("/api/google-drive/connect/callback"),
+  scopes: DEFAULT_SCOPES,
+} as const;
+
+export const buildGoogleDriveAuthUrl = (state: string): string => {
+  const url = new URL(GOOGLE_OAUTH_ENDPOINT);
+  url.searchParams.set("client_id", googleDriveConfig.clientId);
+  url.searchParams.set("redirect_uri", googleDriveConfig.redirectUri);
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("scope", googleDriveConfig.scopes.join(" "));
+  url.searchParams.set("state", state);
+  url.searchParams.set("access_type", "offline");
+  url.searchParams.set("prompt", "consent");
+  return url.toString();
+};
+
+export const exchangeGoogleDriveCode = async (code: string) => {
+  const oauth2Client = new google.auth.OAuth2(
+    googleDriveConfig.clientId,
+    googleDriveConfig.clientSecret,
+    googleDriveConfig.redirectUri,
+  );
+
+  const { tokens } = await oauth2Client.getToken(code);
+
+  if (!tokens.access_token) {
+    throw new Error("No access token returned from Google");
+  }
+
+  if (!tokens.refresh_token) {
+    throw new Error("No refresh token returned from Google");
+  }
+
+  oauth2Client.setCredentials(tokens);
+
+  // Get user email
+  const oauth2 = google.oauth2({ version: "v2", auth: oauth2Client });
+  const userInfo = await oauth2.userinfo.get();
+
+  const expiresAt = tokens.expiry_date
+    ? new Date(tokens.expiry_date)
+    : new Date(Date.now() + 3600 * 1000); // Default 1 hour
+
+  return {
+    accessToken: tokens.access_token,
+    refreshToken: tokens.refresh_token,
+    expiresAt,
+    email: userInfo.data.email ?? "unknown",
+  };
+};
+
+export const refreshGoogleDriveToken = async (refreshToken: string) => {
+  const oauth2Client = new google.auth.OAuth2(
+    googleDriveConfig.clientId,
+    googleDriveConfig.clientSecret,
+    googleDriveConfig.redirectUri,
+  );
+
+  oauth2Client.setCredentials({ refresh_token: refreshToken });
+
+  const { credentials } = await oauth2Client.refreshAccessToken();
+
+  if (!credentials.access_token) {
+    throw new Error("Failed to refresh access token");
+  }
+
+  const expiresAt = credentials.expiry_date
+    ? new Date(credentials.expiry_date)
+    : new Date(Date.now() + 3600 * 1000);
+
+  return {
+    accessToken: credentials.access_token,
+    expiresAt,
+  };
+};
+
+type UploadFileParams = {
+  accessToken: string;
+  fileName: string;
+  content: string;
+  mimeType?: string;
+  folderId?: string;
+};
+
+export const uploadFileToDrive = async (params: UploadFileParams) => {
+  const {
+    accessToken,
+    fileName,
+    content,
+    mimeType = "text/markdown",
+    folderId,
+  } = params;
+
+  const oauth2Client = new google.auth.OAuth2(
+    googleDriveConfig.clientId,
+    googleDriveConfig.clientSecret,
+    googleDriveConfig.redirectUri,
+  );
+
+  oauth2Client.setCredentials({ access_token: accessToken });
+
+  const drive = google.drive({ version: "v3", auth: oauth2Client });
+
+  const fileMetadata: {
+    name: string;
+    mimeType: string;
+    parents?: string[];
+  } = {
+    name: fileName,
+    mimeType,
+  };
+
+  if (folderId) {
+    fileMetadata.parents = [folderId];
+  }
+
+  const media = {
+    mimeType,
+    body: content,
+  };
+
+  const response = await drive.files.create({
+    requestBody: fileMetadata,
+    media,
+    fields: "id, name, webViewLink",
+  });
+
+  return {
+    fileId: response.data.id ?? undefined,
+    fileName: response.data.name ?? fileName,
+    webViewLink: response.data.webViewLink ?? undefined,
+  };
+};

--- a/src/repos/googleDriveConnections.ts
+++ b/src/repos/googleDriveConnections.ts
@@ -1,0 +1,113 @@
+import { eq } from "drizzle-orm";
+import { uuidv7 } from "uuidv7";
+
+import type { Database } from "../clients/drizzle";
+import * as schema from "../db/schema";
+
+type GoogleDriveConnectionRepositoryDeps = {
+  db: Database;
+};
+
+type CreateConnectionInput = {
+  userId: string;
+  email: string;
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: Date;
+  folderId?: string | null;
+  folderName?: string | null;
+};
+
+type UpdateConnectionInput = {
+  userId: string;
+  accessToken?: string;
+  refreshToken?: string;
+  expiresAt?: Date;
+  folderId?: string | null;
+  folderName?: string | null;
+};
+
+export const createGoogleDriveConnectionRepository = ({
+  db,
+}: GoogleDriveConnectionRepositoryDeps) => {
+  const createConnection = async (input: CreateConnectionInput) => {
+    const [connection] = await db
+      .insert(schema.googleDriveConnections)
+      .values({
+        id: uuidv7(),
+        userId: input.userId,
+        email: input.email,
+        accessToken: input.accessToken,
+        refreshToken: input.refreshToken,
+        expiresAt: input.expiresAt,
+        folderId: input.folderId ?? null,
+        folderName: input.folderName ?? null,
+      })
+      .returning();
+
+    return connection;
+  };
+
+  const findConnectionByUserId = async (userId: string) => {
+    const [connection] = await db
+      .select()
+      .from(schema.googleDriveConnections)
+      .where(eq(schema.googleDriveConnections.userId, userId));
+
+    return connection ?? null;
+  };
+
+  const updateConnection = async (input: UpdateConnectionInput) => {
+    const updates: Partial<schema.NewGoogleDriveConnection> = {};
+
+    if (input.accessToken !== undefined) {
+      updates.accessToken = input.accessToken;
+    }
+
+    if (input.refreshToken !== undefined) {
+      updates.refreshToken = input.refreshToken;
+    }
+
+    if (input.expiresAt !== undefined) {
+      updates.expiresAt = input.expiresAt;
+    }
+
+    if (input.folderId !== undefined) {
+      updates.folderId = input.folderId;
+    }
+
+    if (input.folderName !== undefined) {
+      updates.folderName = input.folderName;
+    }
+
+    if (Object.keys(updates).length === 0) {
+      return findConnectionByUserId(input.userId);
+    }
+
+    const [connection] = await db
+      .update(schema.googleDriveConnections)
+      .set(updates)
+      .where(eq(schema.googleDriveConnections.userId, input.userId))
+      .returning();
+
+    return connection ?? null;
+  };
+
+  const deleteConnection = async (userId: string) => {
+    await db
+      .delete(schema.googleDriveConnections)
+      .where(eq(schema.googleDriveConnections.userId, userId));
+  };
+
+  return {
+    createConnection,
+    findConnectionByUserId,
+    updateConnection,
+    deleteConnection,
+  };
+};
+
+export type GoogleDriveConnectionRepository = ReturnType<
+  typeof createGoogleDriveConnectionRepository
+>;
+export type { CreateConnectionInput, UpdateConnectionInput };

--- a/src/repos/index.ts
+++ b/src/repos/index.ts
@@ -2,3 +2,4 @@ export * from "./taskSessions";
 export * from "./workspaces";
 export * from "./users";
 export * from "./subscriptions";
+export * from "./googleDriveConnections";

--- a/src/usecases/google-drive/connectAccount.ts
+++ b/src/usecases/google-drive/connectAccount.ts
@@ -1,0 +1,56 @@
+import type { Env } from "@/app/create-app";
+import { createGoogleDriveConnectionRepository } from "@/repos";
+import { exchangeGoogleDriveCode } from "@/lib/googleDrive";
+
+type ConnectAccount = {
+  code: string;
+  userId: string;
+};
+
+type ConnectAccountResult =
+  | { success: true; email: string }
+  | { success: false; error: string };
+
+export const connectGoogleDriveAccount = async (
+  params: ConnectAccount,
+  ctx: Env["Variables"],
+): Promise<ConnectAccountResult> => {
+  const { code, userId } = params;
+  const { db } = ctx;
+
+  try {
+    const oauthResult = await exchangeGoogleDriveCode(code);
+    const repository = createGoogleDriveConnectionRepository({ db });
+
+    const existing = await repository.findConnectionByUserId(userId);
+
+    if (existing) {
+      // 既存の接続を更新
+      await repository.updateConnection({
+        userId,
+        accessToken: oauthResult.accessToken,
+        refreshToken: oauthResult.refreshToken,
+        expiresAt: oauthResult.expiresAt,
+      });
+    } else {
+      // 新規接続を作成
+      await repository.createConnection({
+        userId,
+        email: oauthResult.email,
+        accessToken: oauthResult.accessToken,
+        refreshToken: oauthResult.refreshToken,
+        expiresAt: oauthResult.expiresAt,
+      });
+    }
+
+    return {
+      success: true,
+      email: oauthResult.email,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "oauth_failed",
+    };
+  }
+};

--- a/src/usecases/google-drive/exportJournal.ts
+++ b/src/usecases/google-drive/exportJournal.ts
@@ -1,0 +1,181 @@
+import type { Env } from "@/app/create-app";
+import { createGoogleDriveConnectionRepository } from "@/repos";
+import { refreshGoogleDriveToken, uploadFileToDrive } from "@/lib/googleDrive";
+import * as schema from "@/db/schema";
+import { and, desc, eq, sql } from "drizzle-orm";
+
+type ExportJournal = {
+  userId: string;
+  date?: string; // YYYY-MM-DD format, defaults to today
+};
+
+type ExportJournalResult =
+  | { success: true; webViewLink: string }
+  | { success: false; error: string };
+
+const generateJournalContent = (
+  tasks: Array<{
+    issueTitle: string;
+    issueId: string | null;
+    issueProvider: string;
+    initialSummary: string;
+    createdAt: Date;
+    events: Array<{
+      eventType: string;
+      summary: string | null;
+      reason: string | null;
+      createdAt: Date;
+    }>;
+  }>,
+  date: string,
+): string => {
+  let content = `# Journal: ${date}\n\n`;
+  content += `## Summary\n${tasks.length} task(s) on this date.\n\n---\n\n`;
+
+  for (const task of tasks) {
+    content += `## ${task.issueTitle}\n\n`;
+    content += `- **Started**: ${task.createdAt.toLocaleString()}\n`;
+    if (task.issueId) {
+      content += `- **Issue**: ${task.issueProvider}#${task.issueId}\n`;
+    }
+    content += `- **Initial Summary**: ${task.initialSummary}\n\n`;
+
+    if (task.events.length > 0) {
+      content += `### Timeline\n\n`;
+      for (const event of task.events) {
+        const timestamp = event.createdAt.toLocaleString();
+        const eventLabel = event.eventType.replace(/_/g, " ").toUpperCase();
+        content += `- **${timestamp}** [${eventLabel}]`;
+        if (event.summary) {
+          content += `: ${event.summary}`;
+        } else if (event.reason) {
+          content += `: ${event.reason}`;
+        }
+        content += `\n`;
+      }
+    }
+
+    content += `\n---\n\n`;
+  }
+
+  return content;
+};
+
+export const exportJournalToGoogleDrive = async (
+  params: ExportJournal,
+  ctx: Env["Variables"],
+): Promise<ExportJournalResult> => {
+  const { userId, date: inputDate } = params;
+  const { db } = ctx;
+
+  try {
+    const repository = createGoogleDriveConnectionRepository({ db });
+    let connection = await repository.findConnectionByUserId(userId);
+
+    if (!connection) {
+      return {
+        success: false,
+        error: "google_drive_not_connected",
+      };
+    }
+
+    // トークンの有効期限チェックと更新
+    const now = new Date();
+    if (connection.expiresAt <= now) {
+      const refreshResult = await refreshGoogleDriveToken(
+        connection.refreshToken,
+      );
+      connection = await repository.updateConnection({
+        userId,
+        accessToken: refreshResult.accessToken,
+        expiresAt: refreshResult.expiresAt,
+      });
+
+      if (!connection) {
+        return {
+          success: false,
+          error: "failed_to_update_token",
+        };
+      }
+    }
+
+    // デフォルトは今日
+    const targetDate = inputDate ?? new Date().toISOString().split("T")[0];
+
+    // タスクとイベントを取得
+    const tasks = await db
+      .select({
+        id: schema.taskSessions.id,
+        issueTitle: schema.taskSessions.issueTitle,
+        issueId: schema.taskSessions.issueId,
+        issueProvider: schema.taskSessions.issueProvider,
+        initialSummary: schema.taskSessions.initialSummary,
+        createdAt: schema.taskSessions.createdAt,
+      })
+      .from(schema.taskSessions)
+      .where(
+        and(
+          eq(schema.taskSessions.userId, userId),
+          sql`DATE(${schema.taskSessions.createdAt}) = ${targetDate}`,
+        ),
+      )
+      .orderBy(desc(schema.taskSessions.createdAt));
+
+    if (tasks.length === 0) {
+      return {
+        success: false,
+        error: "no_tasks_found",
+      };
+    }
+
+    // 各タスクのイベントを取得
+    const tasksWithEvents = await Promise.all(
+      tasks.map(async (task) => {
+        const events = await db
+          .select({
+            eventType: schema.taskEvents.eventType,
+            summary: schema.taskEvents.summary,
+            reason: schema.taskEvents.reason,
+            createdAt: schema.taskEvents.createdAt,
+          })
+          .from(schema.taskEvents)
+          .where(eq(schema.taskEvents.taskSessionId, task.id))
+          .orderBy(schema.taskEvents.createdAt);
+
+        return {
+          ...task,
+          events,
+        };
+      }),
+    );
+
+    // journal コンテンツを生成
+    const journalContent = generateJournalContent(tasksWithEvents, targetDate);
+
+    // Google Drive にアップロード
+    const uploadResult = await uploadFileToDrive({
+      accessToken: connection.accessToken,
+      fileName: `journal-${targetDate}.md`,
+      content: journalContent,
+      folderId: connection.folderId ?? undefined,
+    });
+
+    if (!uploadResult.webViewLink) {
+      return {
+        success: false,
+        error: "upload_failed",
+      };
+    }
+
+    return {
+      success: true,
+      webViewLink: uploadResult.webViewLink,
+    };
+  } catch (error) {
+    console.error("Export journal error:", error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "export_failed",
+    };
+  }
+};


### PR DESCRIPTION
## 対応するIssue

close #81

## やること

- [x] データベーススキーマの追加
  - google_drive_connections テーブルを作成
  - ユーザーごとの Google Drive 接続情報を管理
- [x] Google OAuth 2.0 認証フローの実装
  - OAuth 認証エンドポイント (/api/google-drive/connect/start, /connect/callback)
  - トークン自動更新機能
  - リポジトリとユースケースの作成
- [x] Journal エクスポート機能の実装
  - タスク履歴を Markdown 形式で生成
  - Google Drive API を使用したファイルアップロード
  - エクスポート API エンドポイント (POST /api/google-drive/export/journal)
- [x] 設定画面 UI の実装
  - Google Drive 接続状態の表示
  - 接続・再接続ボタン
  - ジャーナルエクスポートボタン
- [x] googleapis パッケージのインストール
- [x] 環境変数の追加 (GOOGLE_DRIVE_CLIENT_ID, GOOGLE_DRIVE_CLIENT_SECRET)

## やらないこと

- 自動エクスポートのスケジュール機能（将来の機能として検討）
- エクスポート先フォルダの選択機能（現状はルートフォルダにエクスポート）

## 動作確認方法

1. Google Cloud Console で OAuth クライアントを設定
   - プロジェクトを作成または選択
   - APIs & Services → OAuth consent screen で同意画面を設定
   - Credentials → Create Credentials → OAuth client ID
   - アプリケーションタイプ: Web application
   - 承認済みのリダイレクト URI: `{NEXT_PUBLIC_BASE_URL}/api/google-drive/connect/callback`

2. 環境変数を設定
   ```
   GOOGLE_DRIVE_CLIENT_ID=your-client-id.apps.googleusercontent.com
   GOOGLE_DRIVE_CLIENT_SECRET=your-client-secret
   ```

3. マイグレーションを実行
   ```bash
   pnpm db:migrate
   ```

4. アプリケーションを起動し、設定画面から Google Drive に接続

5. 接続後、「今すぐエクスポート」ボタンでジャーナルをエクスポート

## その他補足

- Google Drive API のスコープは `drive.file` と `userinfo.email` を使用
- トークンの有効期限が切れた場合は自動的にリフレッシュされます
- エクスポートされるファイル名は `journal-YYYY-MM-DD.md` 形式
