### PR TITLE
feat: VSCode MCP対応とオンボーディングバグ修正

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Next.js
-NEXT_PUBLIC_BASE_URL=http://localhost:3000
+NEXT_PUBLIC_BASE_URL=https://localhost:3000
 NEXT_PUBLIC_SITE_NAME="Ava"
 
 DATABASE_USER=local

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,9 @@
+{
+  "servers": {
+    "ava": {
+      "url": "https://ava-dusky-gamma.vercel.app/mcp",
+      "type": "http"
+    }
+  },
+  "inputs": []
+}

--- a/content/docs/mcp-setup.mdx
+++ b/content/docs/mcp-setup.mdx
@@ -31,7 +31,7 @@ Claude Code、Cursorなどのコーディングエージェントは、AI技術�
 
 ## 設定方法
 
-<Tabs items={['Claude Code', 'Cursor', 'Codex']} persist groupId="coding-agent">
+<Tabs items={['Codex', 'Claude Code', 'Cursor', 'VSCode']} persist groupId="coding-agent">
   <Tab value="Claude Code">
     ### 1. Claude Codeを起動
 
@@ -148,6 +148,64 @@ Claude Code、Cursorなどのコーディングエージェントは、AI技術�
     ```
 
     Avaのツール一覧が表示されれば成功です。
+
+  </Tab>
+
+  <Tab value="VSCode">
+    ### 1. VSCodeを起動
+
+    VSCodeエディタを開きます。
+
+    ### 2. MCP サーバーを設定
+
+    ワークスペースのルートに `.vscode/mcp.json` ファイルを作成し、以下を追加：
+
+    ```json
+    {
+      "servers": {
+        "ava": {
+          "type": "http",
+          "url": "https://ava-dusky-gamma.vercel.app/mcp"
+        }
+      }
+    }
+    ```
+
+    **設定ファイルの場所:**
+    - ワークスペース固有: `.vscode/mcp.json`（ワークスペースルート）
+
+    **または、コマンドパレットから設定:**
+
+    1. `Cmd/Ctrl + Shift + P` でコマンドパレットを開く
+    2. `MCP: Add Server` を選択
+    3. サーバータイプとして `http` を選択
+    4. サーバー情報を入力
+
+    ### 3. IntelliSenseサポート
+
+    VSCodeでは MCP 設定ファイルに IntelliSense が提供されているため、設定の入力補完が利用できます。エディタ内の「Add Server」ボタンをクリックして、新しいサーバーのテンプレートを追加することもできます。
+
+    ### 4. 初回接続と認証
+
+    1. VSCodeでプロジェクトを開く
+    2. MCP サーバーに初めて接続すると、ブラウザが開いて認証画面が表示されます
+    3. ブラウザで「許可」をクリック
+    4. 認証が完了すると自動的にVSCodeに戻ります
+
+    ### 5. 接続の確認
+
+    VSCodeのチャットで以下のように尋ねてみてください：
+
+    ```
+    利用可能なMCPツールを教えて
+    ```
+
+    以下のツールが表示されれば成功です：
+    - `start_task` - タスクを開始
+    - `update_task` - 進捗を更新
+    - `report_blocked` - 詰まりを報告
+    - `complete_task` - タスクを完了
+    - `list_tasks` - タスク一覧を表示
 
   </Tab>
 

--- a/src/app/(private)/onboarding/setup-mcp/McpSetupTabs.tsx
+++ b/src/app/(private)/onboarding/setup-mcp/McpSetupTabs.tsx
@@ -25,9 +25,21 @@ url = "${mcpUrl}"
     null,
     2,
   );
+  const vscodeJson = JSON.stringify(
+    {
+      servers: {
+        ava: {
+          type: "http",
+          url: mcpUrl,
+        },
+      },
+    },
+    null,
+    2,
+  );
 
   return (
-    <Tabs defaultValue="claude-code" className="space-y-6">
+    <Tabs defaultValue="codex" className="space-y-6">
       <div className="space-y-4">
         <div>
           <h2 className="text-lg font-semibold text-slate-900 mb-2">
@@ -44,6 +56,10 @@ url = "${mcpUrl}"
             セットアップ手順
           </h2>
           <TabsList>
+            <TabsTrigger value="codex" className="gap-2">
+              <Icons.codex className="h-4 w-4 text-slate-900" />
+              Codex
+            </TabsTrigger>
             <TabsTrigger value="claude-code" className="gap-2">
               <Icons.claude className="h-4 w-4 text-[#D97757]" />
               Claude Code
@@ -52,9 +68,9 @@ url = "${mcpUrl}"
               <Icons.cursor className="h-4 w-4" />
               Cursor
             </TabsTrigger>
-            <TabsTrigger value="codex" className="gap-2">
-              <Icons.codex className="h-4 w-4 text-slate-900" />
-              Codex
+            <TabsTrigger value="vscode" className="gap-2">
+              <Icons.vscode className="h-4 w-4 text-[#007ACC]" />
+              VSCode
             </TabsTrigger>
           </TabsList>
         </div>
@@ -173,6 +189,76 @@ url = "${mcpUrl}"
               ~/.cursor/mcp.json
             </code>{" "}
             に貼り付けて保存してください。
+          </p>
+        </div>
+
+        <Alert>
+          <AlertCircle />
+          <AlertTitle>初回接続について</AlertTitle>
+          <AlertDescription>
+            初回接続時にブラウザで認証が求められます。「Allow」をクリックしてアクセスを許可してください。
+          </AlertDescription>
+        </Alert>
+      </TabsContent>
+
+      <TabsContent value="vscode" className="space-y-4">
+        <ol className="space-y-3 text-slate-600">
+          <li className="flex gap-3">
+            <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-slate-900 text-sm font-semibold text-white">
+              1
+            </span>
+            <span>下記の設定をコピー</span>
+          </li>
+          <li className="flex gap-3">
+            <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-slate-900 text-sm font-semibold text-white">
+              2
+            </span>
+            <span>
+              ワークスペースのルートに{" "}
+              <code className="rounded bg-slate-100 px-1.5 py-0.5 text-sm">
+                .vscode/mcp.json
+              </code>{" "}
+              ファイルを作成して貼り付け
+            </span>
+          </li>
+          <li className="flex gap-3">
+            <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-slate-900 text-sm font-semibold text-white">
+              3
+            </span>
+            <span>
+              または、コマンドパレット（
+              <code className="rounded bg-slate-100 px-1.5 py-0.5 text-sm">
+                Cmd/Ctrl + Shift + P
+              </code>
+              ）から{" "}
+              <code className="rounded bg-slate-100 px-1.5 py-0.5 text-sm">
+                MCP: Add Server
+              </code>{" "}
+              を実行して設定を追加
+            </span>
+          </li>
+          <li className="flex gap-3">
+            <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-slate-900 text-sm font-semibold text-white">
+              4
+            </span>
+            <span>初回接続時に認証を承認</span>
+          </li>
+        </ol>
+
+        <div className="space-y-3">
+          <div className="relative rounded-lg bg-slate-900 p-4 group">
+            <CopyButton text={vscodeJson} />
+            <pre className="overflow-x-auto text-sm text-slate-100">
+              <code>{vscodeJson}</code>
+            </pre>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            ワークスペースルートの{" "}
+            <code className="rounded bg-slate-100 px-1.5 py-0.5 text-sm">
+              .vscode/mcp.json
+            </code>{" "}
+            に貼り付けて保存してください。VSCodeでは IntelliSense
+            がサポートされているため、設定の入力補完が利用できます。
           </p>
         </div>
 

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -161,4 +161,139 @@ export const Icons = {
       <path d="M9 14.75C9 16.545 10.455 18 12.25 18H19" />
     </svg>
   ),
+  vscode: (props: IconProps) => (
+    <svg
+      viewBox="0 0 100 100"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <mask
+        id="mask0"
+        mask-type="alpha"
+        maskUnits="userSpaceOnUse"
+        x={0}
+        y={0}
+        width={100}
+        height={100}
+      >
+        <path
+          fillRule="evenodd"
+          clipRule="evenodd"
+          d="M70.9119 99.3171C72.4869 99.9307 74.2828 99.8914 75.8725 99.1264L96.4608 89.2197C98.6242 88.1787 100 85.9892 100 83.5872V16.4133C100 14.0113 98.6243 11.8218 96.4609 10.7808L75.8725 0.873756C73.7862 -0.130129 71.3446 0.11576 69.5135 1.44695C69.252 1.63711 69.0028 1.84943 68.769 2.08341L29.3551 38.0415L12.1872 25.0096C10.589 23.7965 8.35363 23.8959 6.86933 25.2461L1.36303 30.2549C-0.452552 31.9064 -0.454633 34.7627 1.35853 36.417L16.2471 50.0001L1.35853 63.5832C-0.454633 65.2374 -0.452552 68.0938 1.36303 69.7453L6.86933 74.7541C8.35363 76.1043 10.589 76.2037 12.1872 74.9905L29.3551 61.9587L68.769 97.9167C69.3925 98.5406 70.1246 99.0104 70.9119 99.3171ZM75.0152 27.2989L45.1091 50.0001L75.0152 72.7012V27.2989Z"
+          fill="white"
+        />
+      </mask>
+      <g mask="url(#mask0)">
+        <path
+          d="M96.4614 10.7962L75.8569 0.875542C73.4719 -0.272773 70.6217 0.211611 68.75 2.08333L1.29858 63.5832C-0.515693 65.2373 -0.513607 68.0937 1.30308 69.7452L6.81272 74.754C8.29793 76.1042 10.5347 76.2036 12.1338 74.9905L93.3609 13.3699C96.086 11.3026 100 13.2462 100 16.6667V16.4275C100 14.0265 98.6246 11.8378 96.4614 10.7962Z"
+          fill="#0065A9"
+        />
+        <g filter="url(#filter0_d)">
+          <path
+            d="M96.4614 89.2038L75.8569 99.1245C73.4719 100.273 70.6217 99.7884 68.75 97.9167L1.29858 36.4169C-0.515693 34.7627 -0.513607 31.9063 1.30308 30.2548L6.81272 25.246C8.29793 23.8958 10.5347 23.7964 12.1338 25.0095L93.3609 86.6301C96.086 88.6974 100 86.7538 100 83.3334V83.5726C100 85.9735 98.6246 88.1622 96.4614 89.2038Z"
+            fill="#007ACC"
+          />
+        </g>
+        <g filter="url(#filter1_d)">
+          <path
+            d="M75.8578 99.1263C73.4721 100.274 70.6219 99.7885 68.75 97.9166C71.0564 100.223 75 98.5895 75 95.3278V4.67213C75 1.41039 71.0564 -0.223106 68.75 2.08329C70.6219 0.211402 73.4721 -0.273666 75.8578 0.873633L96.4587 10.7807C98.6234 11.8217 100 14.0112 100 16.4132V83.5871C100 85.9891 98.6234 88.1786 96.4586 89.2196L75.8578 99.1263Z"
+            fill="#1F9CF0"
+          />
+        </g>
+        <g
+          style={{
+            mixBlendMode: "overlay",
+          }}
+          opacity={0.25}
+        >
+          <path
+            fillRule="evenodd"
+            clipRule="evenodd"
+            d="M70.8511 99.3171C72.4261 99.9306 74.2221 99.8913 75.8117 99.1264L96.4 89.2197C98.5634 88.1787 99.9392 85.9892 99.9392 83.5871V16.4133C99.9392 14.0112 98.5635 11.8217 96.4001 10.7807L75.8117 0.873695C73.7255 -0.13019 71.2838 0.115699 69.4527 1.44688C69.1912 1.63705 68.942 1.84937 68.7082 2.08335L29.2943 38.0414L12.1264 25.0096C10.5283 23.7964 8.29285 23.8959 6.80855 25.246L1.30225 30.2548C-0.513334 31.9064 -0.515415 34.7627 1.29775 36.4169L16.1863 50L1.29775 63.5832C-0.515415 65.2374 -0.513334 68.0937 1.30225 69.7452L6.80855 74.754C8.29285 76.1042 10.5283 76.2036 12.1264 74.9905L29.2943 61.9586L68.7082 97.9167C69.3317 98.5405 70.0638 99.0104 70.8511 99.3171ZM74.9544 27.2989L45.0483 50L74.9544 72.7012V27.2989Z"
+            fill="url(#paint0_linear)"
+          />
+        </g>
+      </g>
+      <defs>
+        <filter
+          id="filter0_d"
+          x={-8.39411}
+          y={15.8291}
+          width={116.727}
+          height={92.2456}
+          filterUnits="userSpaceOnUse"
+          colorInterpolationFilters="sRGB"
+        >
+          <feFlood floodOpacity={0} result="BackgroundImageFix" />
+          <feColorMatrix
+            in="SourceAlpha"
+            type="matrix"
+            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+          />
+          <feOffset />
+          <feGaussianBlur stdDeviation={4.16667} />
+          <feColorMatrix
+            type="matrix"
+            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"
+          />
+          <feBlend
+            mode="overlay"
+            in2="BackgroundImageFix"
+            result="effect1_dropShadow"
+          />
+          <feBlend
+            mode="normal"
+            in="SourceGraphic"
+            in2="effect1_dropShadow"
+            result="shape"
+          />
+        </filter>
+        <filter
+          id="filter1_d"
+          x={60.4167}
+          y={-8.07558}
+          width={47.9167}
+          height={116.151}
+          filterUnits="userSpaceOnUse"
+          colorInterpolationFilters="sRGB"
+        >
+          <feFlood floodOpacity={0} result="BackgroundImageFix" />
+          <feColorMatrix
+            in="SourceAlpha"
+            type="matrix"
+            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+          />
+          <feOffset />
+          <feGaussianBlur stdDeviation={4.16667} />
+          <feColorMatrix
+            type="matrix"
+            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"
+          />
+          <feBlend
+            mode="overlay"
+            in2="BackgroundImageFix"
+            result="effect1_dropShadow"
+          />
+          <feBlend
+            mode="normal"
+            in="SourceGraphic"
+            in2="effect1_dropShadow"
+            result="shape"
+          />
+        </filter>
+        <linearGradient
+          id="paint0_linear"
+          x1={49.9392}
+          y1={0.257812}
+          x2={49.9392}
+          y2={99.7423}
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor="white" />
+          <stop offset={1} stopColor="white" stopOpacity={0} />
+        </linearGradient>
+      </defs>
+    </svg>
+  ),
 };

--- a/src/middleware/onboarding.test.ts
+++ b/src/middleware/onboarding.test.ts
@@ -160,4 +160,72 @@ describe("onboardingMiddleware", () => {
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ success: true });
   });
+
+  it("should allow incomplete onboarding user to access API endpoints", async () => {
+    vi.spyOn(sessionLib, "getCurrentSession").mockResolvedValue({
+      session: {
+        id: "session-1",
+        userId: "user-1",
+        expiresAt: new Date(Date.now() + 3600 * 1000),
+        createdAt: new Date(),
+      },
+      user: {
+        id: "user-1",
+        name: null,
+        email: null,
+        slackId: "U123",
+        slackTeamId: "T123",
+        workspaceId: "workspace-1",
+        image: null,
+        stripeId: null,
+        onboardingCompletedAt: null, // Not completed
+        createdAt: new Date(),
+      },
+    });
+
+    const app = new Hono();
+    app.get("/api/slack/install/start", onboardingMiddleware, (c) =>
+      c.json({ success: true }),
+    );
+
+    const res = await app.request("/api/slack/install/start", {
+      method: "GET",
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true });
+  });
+
+  it("should allow incomplete onboarding user to access all API paths", async () => {
+    vi.spyOn(sessionLib, "getCurrentSession").mockResolvedValue({
+      session: {
+        id: "session-1",
+        userId: "user-1",
+        expiresAt: new Date(Date.now() + 3600 * 1000),
+        createdAt: new Date(),
+      },
+      user: {
+        id: "user-1",
+        name: null,
+        email: null,
+        slackId: "U123",
+        slackTeamId: "T123",
+        workspaceId: "workspace-1",
+        image: null,
+        stripeId: null,
+        onboardingCompletedAt: null, // Not completed
+        createdAt: new Date(),
+      },
+    });
+
+    const app = new Hono();
+    app.get("/api/health", onboardingMiddleware, (c) =>
+      c.json({ success: true }),
+    );
+
+    const res = await app.request("/api/health", { method: "GET" });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true });
+  });
 });

--- a/src/middleware/onboarding.ts
+++ b/src/middleware/onboarding.ts
@@ -8,6 +8,9 @@ export const onboardingMiddleware = createMiddleware(async (c, next) => {
 
   if (!user) return next();
 
+  // APIエンドポイントはオンボーディングチェックから除外
+  if (path.startsWith("/api/")) return next();
+
   const isOnboardingPath = path.startsWith("/onboarding");
   const completed = !!user.onboardingCompletedAt;
 


### PR DESCRIPTION
## 対応するIssue

close N/A

## やること

- [x] VSCode MCP対応
  - [x] VSCodeタブをオンボーディングページに追加
  - [x] VSCodeタブをドキュメントページに追加
  - [x] VSCodeアイコンを追加
  - [x] タブの順番をCodex, Claude Code, Cursor, VSCodeに変更
  - [x] "VS Code"を"VSCode"に統一
- [x] オンボーディングミドルウェアのバグ修正
  - [x] APIエンドポイント(/api/*)をオンボーディングチェックから除外
  - [x] /onboarding/connect-slackからSlackインストールへの遷移が動作しない問題を修正
  - [x] テストケースを追加（2件）
- [x] 設定ファイル追加
  - [x] .vscode/mcp.jsonを追加（VSCode MCP設定例）
  - [x] .env.exampleをHTTPS対応に更新

## やらないこと

N/A

## スクリーンショット

N/A（UI変更はタブの追加のみ）

## 動作確認方法

### VSCode MCP対応の確認
1. オンボーディングページ（/onboarding/setup-mcp）を開く
2. Codex, Claude Code, Cursor, VSCodeの順でタブが表示されることを確認
3. VSCodeタブをクリックし、セットアップ手順が表示されることを確認
4. ドキュメントページ（/docs/mcp-setup）でも同様に確認

### オンボーディングバグ修正の確認
1. オンボーディング未完了のユーザーでログイン
2. /onboarding/connect-slackページを開く
3. "アプリをインストール"ボタンをクリック
4. /api/slack/install/startにリダイレクトされ、Slack認証画面が表示されることを確認

## その他補足

### 修正した問題
オンボーディングミドルウェアが全てのリクエストをチェックしていたため、APIエンドポイントへのリクエストも/onboardingにリダイレクトされていました。これによりSlackインストールフローが動作しませんでした。

### 解決方法
APIエンドポイント（/api/*）をオンボーディングチェックから除外することで、オンボーディング中でもAPIエンドポイントにアクセスできるようにしました。
